### PR TITLE
Handle different distfile version patterns correctly

### DIFF
--- a/common/targets/DownloadVCRedist.targets
+++ b/common/targets/DownloadVCRedist.targets
@@ -11,10 +11,10 @@
   <UsingTask AssemblyFile="$(PackagesDir)\MSBuildTasks.1.4.0.88\tools\MSBuild.Community.Tasks.dll" TaskName="MSBuild.Community.Tasks.WebDownload" />
 
   <ItemGroup>
-    <VCRedistURI Condition="$(TargetPlatform.Contains('win32'))" Include="http://download.microsoft.com/download/d/d/9/dd9a82d0-52ef-40db-8dab-795376989c03/vcredist_x86.exe">
+    <VCRedistURI Condition="$(TargetPlatform.Contains('win32'))" Include="http://download.microsoft.com/download/5/D/8/5D8C65CB-C849-4025-8E95-C3966CAFD8AE/vcredist_x86.exe">
       <DestinationFileName>vcredist_x86.exe</DestinationFileName>
     </VCRedistURI>
-    <VCRedistURI Condition="$(TargetPlatform.Contains('amd64'))" Include="http://download.microsoft.com/download/2/d/6/2d61c766-107b-409d-8fba-c39e61ca08e8/vcredist_x64.exe">
+    <VCRedistURI Condition="$(TargetPlatform.Contains('amd64'))" Include="http://download.microsoft.com/download/5/D/8/5D8C65CB-C849-4025-8E95-C3966CAFD8AE/vcredist_x64.exe">
       <DestinationFileName>vcredist_x64.exe</DestinationFileName>
     </VCRedistURI>
   </ItemGroup>

--- a/common/targets/Minion.Common.targets
+++ b/common/targets/Minion.Common.targets
@@ -46,13 +46,34 @@
     <Warning Condition="'@(DistFile->Count())' > 1" Text="We may pick the wrong one!" />
     <Error Condition="'%(DistFile.Identity)'==''" Text="No distfiles for $(TargetPlatform) found in $(DistDir)" />
 
+    <!--
+         some observed distfile name patterns:
+
+         salt-0.17.5-63-g6c102d7.win-amd64
+         salt-2014.1.13-414-g987a577.win-amd64
+         salt-2015.2.0-737-gd8f1cff.win-amd64
+         salt-2015.2.0rc1-165-g72d4ab0.win-amd64
+    -->
     <PropertyGroup>
       <DistZipFile>%(DistFile.Identity)</DistZipFile>
       <DisplayVersion Condition="'$(DisplayVersion)'==''">$([System.Text.RegularExpressions.Regex]::Match(%(DistFile.Filename), '(?&lt;=salt-).*(?=.win.*)'))</DisplayVersion>
+
+      <!-- capture origin/develop-generated distfile and append build number -->
       <InternalVersion Condition="'$(InternalVersion)'==''">$([System.Text.RegularExpressions.Regex]::Match(%(DistFile.Filename), '(?&lt;=salt-\d\d)[0-9.]*(?=-.*)')).$(BUILD_NUMBER)</InternalVersion>
+
+      <!-- capture origin/YYYY.M-generated distfile and append build number -->
+      <InternalVersion Condition="'$(InternalVersion)'=='.$(BUILD_NUMBER)'">$([System.Text.RegularExpressions.Regex]::Match(%(DistFile.Filename), '(?&lt;=salt-\d\d)[0-9.]*(?=rc\d\d*-.*)')).$(BUILD_NUMBER)</InternalVersion>
+
+      <!-- capture origin/Major.minor-generated distfile and append build number -->
+      <InternalVersion Condition="'$(InternalVersion)'=='.$(BUILD_NUMBER)'">$([System.Text.RegularExpressions.Regex]::Match(%(DistFile.Filename), '(?&lt;=salt-)[0-9.]*(?=-.*)')).$(BUILD_NUMBER)</InternalVersion>
+
       <DefineConstants>$(DefineConstants);DisplayVersion=$(DisplayVersion);InternalVersion=$(InternalVersion)</DefineConstants>
       <TargetName>Salt-Minion-$(DisplayVersion)-$(TargetPlatform)-Setup</TargetName>
     </PropertyGroup>
+
+    <Message Text="Using Display Version $(DisplayVersion)"/>
+    <Message Text="Using Internal Version $(InternalVersion)"/>
+    <Error Condition="'$(DisplayVersion)'=='' or '$(InternalVersion)'=='.$(BUILD_NUMBER)'" Text="Could not calculate usable versions from discovered distfile %(DistFile.Filename)." />
   </Target>
 
   <!--

--- a/nsis/Salt-Minion-Setup.nsi
+++ b/nsis/Salt-Minion-Setup.nsi
@@ -143,14 +143,14 @@ InstallDirRegKey HKLM "${PRODUCT_DIR_REGKEY}" ""
 ShowInstDetails show
 ShowUnInstDetails show
 
-; Check and install Visual C++ 2008 SP1 redist packages
+; Check and install Visual C++ 2008 SP1 MFC Security Update redist packages
 ; See http://blogs.msdn.com/b/astebner/archive/2009/01/29/9384143.aspx for more info
 Section -Prerequisites
 
-  !define VC_REDIST_X64_GUID "{8220EEFE-38CD-377E-8595-13398D740ACE}"
-  !define VC_REDIST_X86_GUID "{9A25302D-30C0-39D9-BD6F-21E6EC160475}"
-  !define VC_REDIST_X64_URI "http://download.microsoft.com/download/2/d/6/2d61c766-107b-409d-8fba-c39e61ca08e8/vcredist_x64.exe"
-  !define VC_REDIST_X86_URI "http://download.microsoft.com/download/d/d/9/dd9a82d0-52ef-40db-8dab-795376989c03/vcredist_x86.exe"
+  !define VC_REDIST_X64_GUID "{5FCE6D76-F5DC-37AB-B2B8-22AB8CEDB1D4}"
+  !define VC_REDIST_X86_GUID "{9BE518E6-ECC6-35A9-88E4-87755C07200F}"
+  !define VC_REDIST_X64_URI "http://download.microsoft.com/download/5/D/8/5D8C65CB-C849-4025-8E95-C3966CAFD8AE/vcredist_x64.exe"
+  !define VC_REDIST_X86_URI "http://download.microsoft.com/download/5/D/8/5D8C65CB-C849-4025-8E95-C3966CAFD8AE/vcredist_x86.exe"
 
   Var /GLOBAL VcRedistGuid
   Var /GLOBAL VcRedistUri


### PR DESCRIPTION
This pull request addresses two items:

- brings over saltstack/salt@a1d7868d to update vcredist to required version
- addresses saltstack/salt-windows-msi#3 by making the build work w/ 2015.2.0rc1