### PR TITLE
Set MINION_HOSTNAME to ComputerName at install-time

### DIFF
--- a/wix.d/MinionMSI/MinionConfigurationExtensionCA.wxs
+++ b/wix.d/MinionMSI/MinionConfigurationExtensionCA.wxs
@@ -30,6 +30,15 @@
     <CustomAction Id="CADH_UninstallKeepConfig0"  Property="DECA_UninstallKeepConfig0"  Value="root_dir=[INSTALLFOLDER];master=[MASTER_HOSTNAME];id=[MINION_HOSTNAME]" />
     <CustomAction Id="CADH_UninstallKeepConfig1"  Property="DECA_UninstallKeepConfig1"  Value="root_dir=[INSTALLFOLDER];master=[MASTER_HOSTNAME];id=[MINION_HOSTNAME]" />
     <CustomAction Id="CADH_Upgrade"               Property="DECA_Upgrade"               Value="root_dir=[INSTALLFOLDER];master=[MASTER_HOSTNAME];id=[MINION_HOSTNAME]" />
+
+
+    <!-- 2017-04-14 Markus
+    This is an immediate custom action declaration.
+    The custom action sets property MINION_HOSTNAME to Computername
+    You find the the condition whento call it in InstallUISequence in Product.wxs
+    -->    
+    <CustomAction Id="IMCA_SetMinionHostname" Property="MINION_HOSTNAME" Value="[ComputerName]"></CustomAction>
+
     
     <!-- Warning when installing on a client with litte RAM -->
     <CustomAction Id="IMCA_WarnLittleRAM" Script="vbscript"><![CDATA[

--- a/wix.d/MinionMSI/Product.wxs
+++ b/wix.d/MinionMSI/Product.wxs
@@ -17,13 +17,13 @@
 
     <!-- Salt properties                                  -->
     <Property Id="MASTER_HOSTNAME"          Value="salt"                 />
-    <Property Id="MINION_HOSTNAME"          Value="$(env.COMPUTERNAME)"  />
+    <Property Id="MINION_HOSTNAME"          Value="kingbob"              /> <!-- $(env.COMPUTERNAME) is the name of the building machine. Must be set dynamically. Must not be empty.    -->
     <Property Id="KEEP_CONFIG"              Value="1"                    />
     <!-- Windows Installer properties              https://msdn.microsoft.com/en-us/library/windows/desktop/aa370905(v=vs.85).aspx -->
     <Property Id="ARPHELPLINK"              Value="https://saltstack.com/support/"                                                  />
     <Property Id="ARPURLINFOABOUT"          Value="https://saltstack.com/community/"                                                />
     <Property Id="ARPURLUPDATEINFO"         Value="https://docs.saltstack.com/en/latest/topics/releases/"                           />
-    <Property Id="ROOTDRIVE"                Value="$(env.SystemDrive)"   />   <!-- // dont chose disk with the most free space -->
+    <Property Id="ROOTDRIVE"                Value="C:"                   />   <!-- Will become a TODO once path not fixed c:\salt  -->
     <Property Id="ARPPRODUCTICON"           Value="icon"                 />
     <Property Id="MSIRESTARTMANAGERCONTROL" Value="Disable"              />
     <Property Id="MsiLogging"               Value="v"                    />  <!--  Logging into %TEMP%\MSIxxxxx.LOG  https://msdn.microsoft.com/en-us/library/windows/desktop/aa370322.aspx -->
@@ -49,8 +49,9 @@
     
       
     <InstallUISequence>
-      <Custom Action='IMCA_read_NSIS'             Before='FindRelatedProducts'>NOT Installed</Custom>      
-      <Custom Action="IMCA_WarnLittleRAM"         After='CostFinalize'        >NOT Installed</Custom>      
+      <Custom Action="IMCA_SetMinionHostname"     Before='IMCA_read_NSIS'     >NOT Installed</Custom>
+      <Custom Action='IMCA_read_NSIS'             Before='FindRelatedProducts'>NOT Installed</Custom>
+      <Custom Action="IMCA_WarnLittleRAM"         After='CostFinalize'        >NOT Installed</Custom>
 
       <LaunchConditions After="AppSearch" /> <!-- Benefit is unclear. Was used when detecting MFC. Probably not needed. -->
     </InstallUISequence>


### PR DESCRIPTION
This is a bug fix.

Previously
MINION_HOSTNAME was set to ComputerName at build-time

Therefore, the name of the build-client was stored as property in the msi, and appeared as default.

Reported by @twangboy 