### PR TITLE
Add domain controllers to supported list

### DIFF
--- a/wix.d/MinionMSI/Product.wxs
+++ b/wix.d/MinionMSI/Product.wxs
@@ -12,6 +12,7 @@
     <Condition Message="Installation requires Windows XP, Windows Server 2008, or higher. (found MsiNTProductType [MsiNTProductType], VersionNT [VersionNT])">
       Installed
       or MsiNTProductType = 1 and  VersionNT >= 501
+      or MsiNTProductType = 2 and  VersionNT >= 600
       or MsiNTProductType = 3 and  VersionNT >= 600
     </Condition>
 


### PR DESCRIPTION
Currently if you attempt to install the MSI on a AD domain controller you will get an error `Installation requires Windows XP, Windows Server 2008, or higher.`

This change allows you to install the MSI on a AD server running Windows Server 2008 or higher.