### PR TITLE
Bugfix insert value after comment or end in minionconfig file

### DIFF
--- a/wix.d/MinionConfigurationExtension/MinionConfiguration.cs
+++ b/wix.d/MinionConfigurationExtension/MinionConfiguration.cs
@@ -446,12 +446,12 @@ def id_function():
                 if (!found && configLines_in[i].StartsWith("#" + key + ":")) {
                     found = true;
                     session.Log("...insert_value_after_comment_or_end..found the # in       {0}", configLines_in[i]);
-                    configLines_out[configLines_out_index++] = value;
+                    configLines_out[configLines_out_index++] = key + ": " + value;
                 }
             }
             if (!found) {
                 session.Log("...insert_value_after_comment_or_end..end");
-                configLines_out[configLines_out_index++] = value;
+                configLines_out[configLines_out_index++] = key + ": " + value;
             }
             File.WriteAllLines(MINION_CONFIGFILE, configLines_out);
         }


### PR DESCRIPTION
This commit fixes a bug

In the default config file there is the entry

    #master

Expected behaviour: the msi installer adds a line

    #master
    master: salt


Current behaviour: the msi installer adds a line

    #master
    salt


Same for minion id