### PR TITLE
Use ^ for newline in MINION_CONFIG

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ You can set a new master public key with `MASTER_KEY`, but you must convert it i
 
 ### `MINION_CONFIG`
 
-If `MINION_CONFIG` is set, the installer creates the file `c:\salt\conf\minion` with the content. To include whitespace, use double quotes around. For line breaks, use ";".
+If `MINION_CONFIG` is set, the installer creates the file `c:\salt\conf\minion` with the content. To include whitespace, use double quotes around. For line breaks, use "^".
 
-Example `MINION_CONFIG="a: A;b: B"` results in:
+Example `MINION_CONFIG="a: A^b: B"` results in:
 
     a: A
     b: B

--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ You can set a new master public key with `MASTER_KEY`, but you must convert it i
 
 ### `MINION_CONFIG`
 
-If `MINION_CONFIG` is set, the installer creates the file `c:\salt\conf\minion` with the content. To include whitespace, use double quotes around.
+If `MINION_CONFIG` is set, the installer creates the file `c:\salt\conf\minion` with the content. To include whitespace, use double quotes around. For line breaks, use ";".
 
-Example `MINION_CONFIG="a: A,b: B"` results in:
+Example `MINION_CONFIG="a: A;b: B"` results in:
 
     a: A
     b: B

--- a/install_GUI-New-MINION_CONFIG.cmd
+++ b/install_GUI-New-MINION_CONFIG.cmd
@@ -3,4 +3,4 @@
 for /f "delims=" %%a in ('dir /b wix.d\MinionMSI\bin\Release\*.msi')   do @set "msi=%%a"
 
 @echo on
-msiexec /i wix.d\MinionMSI\bin\Release\%msi% CONFIG_TYPE=New MINION_ID_FUNCTION=socket.gethostname() MINION_CONFIG="a: A;bb: BB;ccc444: CCC" MASTER=ma111 MINION_ID=mi111
+msiexec /i wix.d\MinionMSI\bin\Release\%msi% CONFIG_TYPE=New MINION_ID_FUNCTION=socket.gethostname() MINION_CONFIG="a: A^bb: BB^ccc444: CCC"

--- a/install_GUI-New-MINION_CONFIG.cmd
+++ b/install_GUI-New-MINION_CONFIG.cmd
@@ -1,0 +1,6 @@
+@echo off
+:: Get the (last) file name
+for /f "delims=" %%a in ('dir /b wix.d\MinionMSI\bin\Release\*.msi')   do @set "msi=%%a"
+
+@echo on
+msiexec /i wix.d\MinionMSI\bin\Release\%msi% CONFIG_TYPE=New MINION_ID_FUNCTION=socket.gethostname() MINION_CONFIG="a: A;bb: BB;ccc444: CCC" MASTER=ma111 MINION_ID=mi111

--- a/install_GUI-New.cmd
+++ b/install_GUI-New.cmd
@@ -1,6 +1,0 @@
-@echo off
-:: Get the (last) file name
-for /f "delims=" %%a in ('dir /b wix.d\MinionMSI\bin\Release\*.msi')   do @set "msi=%%a"
-
-@echo on
-msiexec /i wix.d\MinionMSI\bin\Release\%msi% CONFIG_TYPE=New MINION_ID_FUNCTION=socket.gethostname() MINION_CONFIG="a: A,bb: BB,ccc444: CCC" MASTER=ma111 MINION_ID=mi111

--- a/wix.d/MinionConfigurationExtension/MinionConfiguration.cs
+++ b/wix.d/MinionConfigurationExtension/MinionConfiguration.cs
@@ -358,7 +358,7 @@ def id_function():
             session.Log(@"...save_config_DECAC");
             string kwargs_in_commata = MinionConfigurationUtilities.get_property_DECAC(session, "minion_config");
             if (kwargs_in_commata.Length > 0) {
-                string lines = kwargs_in_commata.Replace(",", Environment.NewLine);
+                string lines = kwargs_in_commata.Replace(";", Environment.NewLine);
                 MinionConfigurationUtilities.Writeln_file(session, @"C:\salt\conf", "minion", lines);
             }
         }

--- a/wix.d/MinionConfigurationExtension/MinionConfiguration.cs
+++ b/wix.d/MinionConfigurationExtension/MinionConfiguration.cs
@@ -358,7 +358,7 @@ def id_function():
             session.Log(@"...save_config_DECAC");
             string kwargs_in_commata = MinionConfigurationUtilities.get_property_DECAC(session, "minion_config");
             if (kwargs_in_commata.Length > 0) {
-                string lines = kwargs_in_commata.Replace(";", Environment.NewLine);
+                string lines = kwargs_in_commata.Replace("^", Environment.NewLine);
                 MinionConfigurationUtilities.Writeln_file(session, @"C:\salt\conf", "minion", lines);
             }
         }


### PR DESCRIPTION
The caret (^) is better for newline because it not a "Indicator Character" in YAML, while the comma (,) is. The semicolon (;) would be nicer, but msi does allow it in parameters

Quote YAML spec chapter [5.3. Indicator Characters](https://yaml.org/spec/1.1/#id868988):

Indicators are characters that have special semantics used to describe the structure and content of a YAML document.