### PR TITLE
Reduced dependencies

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -28,8 +28,7 @@ commands, all from within the IDE. Note that this requires:
 The build client is where the msi installer is built.
 
 - 64bit Windows 10
-- Salt clone in `c:\git\salt\`
-- This clone in `c:\git\salt-windows-msi\`
+- The Git repositories `salt` and `salt-windows-msi`
 - .Net 3.5 SDK (for WiX)<sup>*</sup>
 - Microsoft_VC90_CRT_x86_x64.msm from Visual Studio 2008 SP2 in `c:\salt_msi_resources\`<sup>**</sup>
 - Microsoft_VC140_CRT_x64.msm from Visual Studio 2015 in `c:\salt_msi_resources\`<sup>**</sup>
@@ -49,7 +48,7 @@ Optionally: [Visual Studio Extension](https://marketplace.visualstudio.com/items
 
 Execute
 
-    cd c:\git\salt\pkg\windows
+    cd c:\dev\salt\pkg\windows
     git checkout v2018.3.4
     git checkout .
     git clean -fd
@@ -68,7 +67,7 @@ then execute
 
 Execute
 
-    cd c:\git\salt-windows-msi
+    cd c:\dev\salt-windows-msi
     build_env.cmd
     build.cmd
 

--- a/clean.cmd
+++ b/clean.cmd
@@ -1,5 +1,5 @@
 :: 2016-11-07  Markus Kramer   version required to clean. This is strange.
 
 "%ProgramFiles(x86)%"\MSBuild\14.0\Bin\msbuild.exe msbuild.proj /nologo /clp:ErrorsOnly /t:clean /p:Version=2000.0.0
-rmdir /s /q c:\git\salt-windows-msi\wix.d\MinionMSI\obj
-rmdir /s /q c:\git\salt-windows-msi\wix.d\MinionMSI\bin
+rmdir /s /q wix.d\MinionMSI\obj
+rmdir /s /q wix.d\MinionMSI\bin

--- a/msbuild.d/Minion.Common.targets
+++ b/msbuild.d/Minion.Common.targets
@@ -32,8 +32,8 @@
     ================================================================================
        setVersionProperties
 
-        Queries git for salt DisplayVersion and InternalVersion 
-        These msbuild variable are sent to WiX by in two different manners:
+        Regarding DisplayVersion and InternalVersion:
+        These msbuild variables are sent to WiX by in two different manners:
            Output PropertyName
            DefineConstants magic
 
@@ -43,18 +43,7 @@
   -->
   <Target Name="setVersionProperties">
 
-    <!--  
-    ConsoleToMsBuild in Exec requires ToolsVersion="12.0" (Microsoft Build Tools 2013)
-     
-    Exec runs in MSBuildProjectDirectory
-    This depends on the target, it is      C:\git\salt-windows-msi\wix\MinionMSI       or    C:\git\salt-windows-msi
-    So MSBuildProjectDirectory is not very usefull.
-    Quirk: using hard coded path
-    Maybe abandon to get the version from within msbuild, and give it to msbuild as a parameter, as saxonww did.
-    -->
     <Message Text="  ****************** msbuild.d/Minion.Common.targets ***************************   "/>
-    <Exec Command="C:\Python27\python \git\salt\salt\version.py"     ConsoleToMsBuild="true"><Output TaskParameter="ConsoleOutput" PropertyName="DisplayVersion"  /></Exec>
-    <Exec Command="C:\Python27\python \git\salt\salt\version.py msi" ConsoleToMsBuild="true"><Output TaskParameter="ConsoleOutput" PropertyName="InternalVersion" /></Exec>
 
     <Error Condition="'$(DisplayVersion)'==''"  Text="DisplayVersion must be set" />
     <Error Condition="'$(InternalVersion)'==''" Text="InternalVersion must be set" />


### PR DESCRIPTION
Removed the dependency on two hard coded directories:

- `C:\git`
- `C:\python27`

Moved the Salt version detection out of msbuild (XML) into `build.cmd`.

