### PR TITLE
Speed up build by excluding dir in Windows defender

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -197,6 +197,7 @@ Because of this restriction, the builder generates an internal version:
 
 Distutils contains bin/Lib/distutils/command/bdist_msi.py, which probably does not work.
 
+To Speed up the build process, you could exclude your git repository from Windows defender (Virus & threat protection settings)
 
 ### From upgrade code to uninstallstring
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This creates a Salt Minion msi installer using [WiX](http://wixtoolset.org).
 
-The focus is on 64bit, unattended install.
+The focus is on unattended install.
 
 ## Introduction
 

--- a/build.cmd
+++ b/build.cmd
@@ -1,3 +1,1 @@
-PowerShell Set-MpPreference -DisableRealtimeMonitoring $true
 PowerShell -ExecutionPolicy RemoteSigned -File build.cmd.ps1
-PowerShell Set-MpPreference -DisableRealtimeMonitoring $false


### PR DESCRIPTION
To speed up the build, exclude directory in Windows defender.

Switching Defender off and on is too time consuming.
