### PR TITLE
Removes WixQuietExecCmdLine exercise "where whoami"

### DIFF
--- a/wix.d/MinionMSI/Product.wxs
+++ b/wix.d/MinionMSI/Product.wxs
@@ -96,10 +96,6 @@ xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
     <CustomAction Id="uninst_NSIS1_DECAX"      DllEntry="WixQuietExec"         Execute="deferred"  Return="check"   BinaryKey="WixCA" Impersonate="no"/>
     <CustomAction Id="uninst_NSIS2_DECAH"      Property="uninst_NSIS2_DECAX"     Value='"C:\salt\uninst.exe" /S'/>
     <CustomAction Id="uninst_NSIS2_DECAX"      DllEntry="WixQuietExec"         Execute="deferred"  Return="check"   BinaryKey="WixCA" Impersonate="no"/>
-    <Property     Id="whereexe"                                                  Value='where'/>
-    <CustomAction Id="learn_exec_IMCAH"        Property="WixQuietExecCmdLine"    Value='"[whereexe]" whoami'/>
-    <CustomAction Id="learn_exec_IMCAX"        DllEntry="WixQuietExec"         Execute="immediate" Return="ignore"  BinaryKey="WixCA"  />
-
 
     <!-- Preparation when NSIS not only installs into fixed path C:\salt.    Remove uninst.exe from NSIS_UNINSTALLSTRING -->
     <CustomAction Id="get_NSIS_uninstdir_IMCAX" Script="vbscript">
@@ -114,8 +110,6 @@ xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
     <InstallUISequence>         <!-- * * * * * * * * * * * * * * * * * * Sequence with GUI * * * * * * * * * * * * * * * * *  -->
       <Custom Action="get_NSIS_uninstdir_IMCAX"    Before='LaunchConditions'         >NSIS_UNINSTALLSTRING</Custom>
       <Custom Action='ReadConfig_IMCAC'            Before='MigrateFeatureStates'     >NOT Installed</Custom>
-      <Custom Action='learn_exec_IMCAH'            Before='learn_exec_IMCAX'        />
-      <Custom Action="learn_exec_IMCAX"            Before='MigrateFeatureStates'    />
 
       <LaunchConditions After="AppSearch" /> <!-- Benefit is unclear. Was used when detecting MFC. Probably not needed. -->
     </InstallUISequence>


### PR DESCRIPTION
### Cleans up code
Remove an exercise with the `WixQuietExecCmdLine` Element that executes "where whoami": 
- Only effect was logging in the MSI.log.

Should not be in the production msi.

