### PR TITLE
Optionally hide in Programs and Features

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Example: uninstall and remove configuration
 - Creates a very verbose log file, by default %TEMP%\MSIxxxxx.LOG, where xxxxx are 5 random lowercase letters or numbers. The name of the log can be specified with `msiexec /log example.log`
 - Upgrades NSIS installations __UNDER REVIEW__
 
-Salt Minion-specific msi-properties:
+Salt Minion-specific and generic msi-properties:
 
   Property              |  Default                | Comment
  ---------------------- | ----------------------- | ------
@@ -45,6 +45,7 @@ Salt Minion-specific msi-properties:
  `CONFIG_TYPE`          | `Existing`              | Or `Custom` or `Default`. See below.
  `CUSTOM_CONFIG`        |                         | Name of a custom config file in the same path as the installer or full path. Requires `CONFIG_TYPE=Custom`. __ONLY FROM COMMANDLINE__
  `INSTALLFOLDER`        | `C:\salt\`              | Where to install the Minion  __DO NOT CHANGE (yet)__  --- __BLOCKED BY__ [issue#38430](https://github.com/saltstack/salt/issues/38430)
+ `ARPSYSTEMCOMPONENT`   |                         | Set to 1 to hide "Salt Minion" in "Programs and Features".
 
 
 Master and id are read from file `C:\salt\conf\minion`

--- a/wix.d/MinionMSI/ProductUIsettings.wxs
+++ b/wix.d/MinionMSI/ProductUIsettings.wxs
@@ -9,13 +9,13 @@
         <Control Id="BannerLine"   Type="Line"       X="0"   Y="44"  Width="370" Height="0" />
         <Control Id="BottomLine"   Type="Line"       X="0"   Y="234" Width="370" Height="0" />
 
-        <Control Id="MasterLabel"  Type="Text"       X="20"  Y="75"  Width="280" Height="15" Transparent="yes" NoPrefix="yes" Text="Master (single hostname or IP address):" />
-        <Control Id="MasterId"     Type="Edit"       X="20"  Y="90"  Width="190" Height="15" Property="MASTER" />
+        <Control Id="MasterLabel"  Type="Text"       X="20"  Y="55"  Width="280" Height="15" Transparent="yes" NoPrefix="yes" Text="Master (single hostname or IP address):" />
+        <Control Id="MasterId"     Type="Edit"       X="30"  Y="70"  Width="190" Height="15" Property="MASTER" />
+        <Control Id="MinionLabel"  Type="Text"       X="20"  Y="85"  Width="280" Height="15" Transparent="yes" NoPrefix="yes" Text="Minion:" />
+        <Control Id="MinionId"     Type="Edit"       X="30"  Y="100" Width="190" Height="15" Property="MINION_ID" />
+        <Control Id="StartService" Type="CheckBox"   X="20"  Y="140" Width="280" Height="15" Property="START_MINION"       CheckBoxValue="1" Text="&amp;Start salt-minion service immediately"/>
+        <Control Id="HideInARP"    Type="CheckBox"   X="20"  Y="155" Width="280" Height="15" Property="ARPSYSTEMCOMPONENT" CheckBoxValue="1" Text="&amp;Hide in 'Programs and Features'"/>
 
-        <Control Id="MinionLabel"  Type="Text"       X="20"  Y="120" Width="280" Height="15" Transparent="yes" NoPrefix="yes" Text="Minion:" />
-        <Control Id="MinionId"     Type="Edit"       X="20"  Y="135" Width="190" Height="15" Property="MINION_ID" />
-
-        <Control Id="StartService" Type="CheckBox"   X="20"  Y="210" Width="280" Height="15" Property="START_MINION" CheckBoxValue="1" Text="&amp;Start salt-minion service immediately"/>
         <Control Id="Next"         Type="PushButton" X="236" Y="243" Width="56"  Height="17" Default="yes" Text="!(loc.WixUINext)" />
         <Control Id="Back"         Type="PushButton" X="180" Y="243" Width="56"  Height="17"               Text="!(loc.WixUIBack)" />
         <Control Id="Cancel"       Type="PushButton" X="304" Y="243" Width="56"  Height="17" Cancel="yes"  Text="!(loc.WixUICancel)"/>


### PR DESCRIPTION
The Minion installers gets documentation and a switch (for a MSI property) to hide the installation in Programs and Features.

### Related issues

https://github.com/saltstack/salt-windows-msi/issues/7


