### PR TITLE
Retain previous custom grains and modules

### DIFF
--- a/wix.d/MinionConfigurationExtension/MinionConfiguration.cs
+++ b/wix.d/MinionConfigurationExtension/MinionConfiguration.cs
@@ -41,7 +41,8 @@ namespace MinionConfigurationExtension {
               *   A GUI installation will show these msi properties because this function is called before the GUI.
               *   
               */
-            session.Log("...Begin ReadConfig_IMCAC");
+            session.Log("...BEGIN ReadConfig_IMCAC");
+            session.Log("...VERSION MinionConfigurationExtensionCA 1");
             String master_from_previous_installation = "";
             String id_from_previous_installation = "";
             // Read master and id from main config file
@@ -147,7 +148,7 @@ namespace MinionConfigurationExtension {
                 }
                 File.WriteAllText(master_public_key_filename, new_master_pub_key);
             }
-            session.Log("...End ReadConfig_IMCAC");
+            session.Log("...END ReadConfig_IMCAC");
             return ActionResult.Success;
         }
 
@@ -192,7 +193,8 @@ namespace MinionConfigurationExtension {
              *   This would be cleaner code
              *      uninst /S  does leave the installdir while    uninst /s /DeleteInstallDir  delete the installdir, both silentyl
             */
-            session.Log("...Begin del_NSIS_DECAC");
+            session.Log("...BEGIN del_NSIS_DECAC");
+            session.Log("...VERSION MinionConfigurationExtensionCA 1");
             RegistryKey reg = Registry.LocalMachine;
             // ?When this is under    SOFTWARE\WoW6432Node
             string Salt_uninstall_regpath64 = @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Salt Minion";
@@ -221,7 +223,7 @@ namespace MinionConfigurationExtension {
                 try { File.Delete(@"c:\salt\nssm.exe"); } catch (Exception ex) { MinionConfigurationUtilities.just_ExceptionLog("", session, ex); }
                 try { foreach (FileInfo fi in new DirectoryInfo(@"c:\salt").GetFiles("salt*.*")) { fi.Delete(); } } catch (Exception) {; }
             }
-            session.Log("...End del_NSIS_DECAC");
+            session.Log("...END del_NSIS_DECAC");
             return ActionResult.Success;
         }
 
@@ -239,7 +241,8 @@ namespace MinionConfigurationExtension {
              *
              */
             // Must have this signature or cannot uninstall not even write to the log
-            session.Log("...WriteConfig_DECAC BEGIN");
+            session.Log("...BEGIN WriteConfig_DECAC");
+            session.Log("...VERSION MinionConfigurationExtensionCA 1");
             string minion_config = MinionConfigurationUtilities.get_property_DECAC(session, "minion_config");
             if (minion_config.Length > 0) {
                 apply_minion_config_DECAC(session, minion_config);
@@ -254,7 +257,7 @@ namespace MinionConfigurationExtension {
                 }
                 save_custom_config_file_if_config_type_demands_DECAC(session);
             }
-            session.Log("...WriteConfig_DECAC END");
+            session.Log("...END WriteConfig_DECAC");
             return ActionResult.Success;
         }
 

--- a/wix.d/MinionMSI/Product.md
+++ b/wix.d/MinionMSI/Product.md
@@ -84,7 +84,7 @@ Salt creates life time data which must be removed, some of it during upgrade, al
 
 Wix `util:RemoveFolderEx` removes any data transaction safe, but counts an upgrade as an uninstallation.
 - for salt/bin/** (mostly *.pyc) this is appropriate.
-- for salt/var/** (grains and modules) we restrict deletion to "only on uninstall" (`REMOVE ~= "ALL"`).
+- for salt/var/** (custom grains and modules) we restrict deletion to "only on uninstall" (`REMOVE ~= "ALL"`).
 
 
 ### Delete minion_id file

--- a/wix.d/MinionMSI/Product.md
+++ b/wix.d/MinionMSI/Product.md
@@ -83,7 +83,7 @@ When uninstalling an application, an msi only removes exactly the data it instal
 Salt creates life time data which must be removed, some of it during upgrade, all of it (except configuration) during uninstall.
 
 Wix `util:RemoveFolderEx` removes any data transaction safe, but counts an upgrade as an uninstallation.
-- for salt/bin/** (mosltly *.py) this is appropriate.
+- for salt/bin/** (mostly *.pyc) this is appropriate.
 - for salt/var/** (grains and modules) we restrict deletion to "only on uninstall" (`REMOVE ~= "ALL"`).
 
 

--- a/wix.d/MinionMSI/Product.md
+++ b/wix.d/MinionMSI/Product.md
@@ -74,6 +74,19 @@ In the DECAC:
     session.CustomActionData["master"]      THIS IS OK
     session.CustomActionData["mister"]      THIS WILL CRASH
 
+
+### Conditional removal of lifetime data
+"Lifetime data" means any change that was not installed by the msi (during the life time of the application).
+
+When uninstalling an application, an msi only removes exactly the data it installed, unless explicit actions are taken.
+
+Salt creates life time data which must be removed, some of it during upgrade, all of it (except configuration) during uninstall.
+
+Wix `util:RemoveFolderEx` removes any data transaction safe, but counts an upgrade as an uninstallation.
+- for salt/bin/** (mosltly *.py) this is appropriate.
+- for salt/var/** (grains and modules) we restrict deletion to "only on uninstall" (`REMOVE ~= "ALL"`).
+
+
 ### Delete minion_id file
 Alternatives
 

--- a/wix.d/MinionMSI/Product.wxs
+++ b/wix.d/MinionMSI/Product.wxs
@@ -147,8 +147,11 @@ xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
 
     <Feature Id="ProductFeature" Title="Minion" Level="1">
       <ComponentGroupRef Id="ProductComponents" />
-      <ComponentRef      Id="RemoveFolderEx_BINFOLDER_Component" />
-      <ComponentRef      Id="RemoveFolderEx_VARFOLDER_Component"/>
+      <ComponentRef      Id="RemoveFolderEx_BINFOLDER_Component" /> <!-- On uninstall and upgrade -->
+      <Feature     Level="0" Id="Only_on_uninstall_not_upgrade" Display="hidden" AllowAdvertise="no">
+        <Condition Level="1">REMOVE ~= "ALL"</Condition>
+        <ComponentRef Id="RemoveFolderEx_VARFOLDER_Component"/>
+      </Feature>
 
       <Feature Id="VC120" Title="VC++ 2013" AllowAdvertise="no" Display="hidden"><MergeRef Id="MSM_VC120_CRT"/></Feature>
       <Feature Id="VC140" Title="VC++ 2015" AllowAdvertise="no" Display="hidden"><MergeRef Id="MSM_VC140_CRT"/></Feature>
@@ -220,7 +223,7 @@ xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
         <RegistryValue Root="HKLM" Key="$(var.RegDir)" Name="$(var.RegVal_BINFOLDER)"
                 Type="string" Value="[BINFOLDER]" KeyPath="yes"/>
         <CreateFolder Directory="BINFOLDER"/>
-        <util:RemoveFolderEx Property="BINFOLDER" On="uninstall"/>
+        <util:RemoveFolderEx Property="BINFOLDER" On="uninstall"/> <!-- Includes upgrade -->
         <RemoveFolder Id="BINFOLDER" On="uninstall"/>
       </Component>
     </DirectoryRef>
@@ -230,7 +233,7 @@ xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
         <RegistryValue Root="HKLM" Key="$(var.RegDir)" Name="$(var.RegVal_VARFOLDER)"
                 Type="string" Value="[VARFOLDER]" KeyPath="yes"/>
         <CreateFolder Directory="VARFOLDER"/>
-        <util:RemoveFolderEx Property="VARFOLDER" On="uninstall"/>
+        <util:RemoveFolderEx Property="VARFOLDER" On="uninstall"/> <!-- Includes upgrade -->
         <RemoveFolder Id="VARFOLDER" On="uninstall"/>
       </Component>
     </DirectoryRef>


### PR DESCRIPTION
## Conditional removal of lifetime data
"Lifetime data" means any change that was not installed by the msi (during the life time of the application).

When uninstalling an application, an msi only removes exactly the data it installed, unless explicit actions are taken.

Salt creates life time data which must be removed, some of it during upgrade, all of it (except configuration) during uninstall.

Wix `util:RemoveFolderEx` removes any data transaction safe, but counts an upgrade as an uninstallation.
- for salt/bin/** (mostly *.pyc) this is appropriate.
- for salt/var/** (custom grains and modules) we restrict deletion to "only on uninstall" (`REMOVE ~= "ALL"`).


### Related issues
- Issue https://github.com/saltstack/salt-windows-msi/issues/62


### Tested
[Here](https://github.com/markuskramerIgitt/LearnWix3/blob/master/RemoveFolderEx-1-conditionallly/README.md)



### Visilibity/effectivity
Because removal of lifetime data is the task of the previous installer, the fix will only be effective for the upgrade of the fixed installer.