### PR TITLE
Only ssm.exe shall get no automatic GUID, not all files ending in ssm.exe

### DIFF
--- a/msbuild.d/BuildDistFragment.xsl
+++ b/msbuild.d/BuildDistFragment.xsl
@@ -23,7 +23,7 @@ xmlns:msxsl="urn:schemas-microsoft-com:xslt" exclude-result-prefixes="msxsl">
 
 <!-- BEGIN remove component for ssm.exe from dist-amd64.wxs because it must be in service.wxs -->
 <!--key to detect ssmexe-->
-<xsl:key name="ssmexe" match="wix:Component[contains(wix:File/@Source, 'ssm.exe')]" use="@Id"/>
+<xsl:key name="ssmexe" match="wix:Component[contains(wix:File/@Source, '\ssm.exe')]" use="@Id"/>
 
 <!--Match and ignore ssmexe  -->
 <xsl:template match="wix:Component[key('ssmexe', @Id)]"/>


### PR DESCRIPTION
ssm.exe is getting an handmade GUID in services.wxs

Therefore it must not get an automatic GUID


This change restricts file which get no automatic GUIDS to those called ssm.exe

Before, no files ending in ssm.exe did get automatic GUIDS 

Files without GUID are not assembled.
