### PR TITLE
Bugfix remove folder

### DIFF
--- a/uninstall_GUI_REMOVE_CONFIG.cmd
+++ b/uninstall_GUI_REMOVE_CONFIG.cmd
@@ -1,0 +1,6 @@
+@echo off
+:: Get the file name
+for /f "delims=" %%a in ('dir /b wix.d\MinionMSI\bin\Release\*.msi')   do @set "msi=%%a"
+
+@echo on
+msiexec /X wix.d\MinionMSI\bin\Release\%msi% REMOVE_CONFIG=1

--- a/wix.d/MinionMSI/Product.wxs
+++ b/wix.d/MinionMSI/Product.wxs
@@ -108,6 +108,10 @@ xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
       on error resume next
       CreateObject("Scripting.FileSystemObject").GetFolder(Session.Property("CONFFOLDER")).Delete(True)
     </CustomAction>
+    <CustomAction Id="delete_VARFOLDER_CAX" Script="vbscript">
+      on error resume next
+      CreateObject("Scripting.FileSystemObject").GetFolder(Session.Property("VARFOLDER")).Delete(True)
+    </CustomAction>
 
     <InstallUISequence>         <!-- * * * * * * * * * * * * * * * * * * Sequence with GUI * * * * * * * * * * * * * * * * *  -->
       <Custom Action="get_NSIS_uninstdir_IMCAX"    Before='LaunchConditions'         >NSIS_UNINSTALLSTRING</Custom>
@@ -125,6 +129,7 @@ xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
       <Custom Action="uninst_NSIS2_DECAX"          Before='ProcessComponents'       >nsis_uninst_waits_yes</Custom>
 
       <Custom Action='delete_config_CAX'           After='RemoveFiles'              >(REMOVE ~= "ALL") and REMOVE_CONFIG</Custom>
+      <Custom Action='delete_VARFOLDER_CAX'        After='RemoveFiles'              >REMOVE ~= "ALL"</Custom>
 
       <Custom Action='WriteConfig_CADH'
               Before='WriteConfig_DECAC'                                            >NOT Installed</Custom>
@@ -151,10 +156,6 @@ xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
     <Feature Id="ProductFeature" Title="Minion" Level="1">
       <ComponentGroupRef Id="ProductComponents" />
       <ComponentRef      Id="RemoveFolderEx_BINFOLDER_Component" /> <!-- On uninstall and upgrade -->
-      <Feature     Level="0" Id="Only_on_uninstall_not_upgrade" Display="hidden" AllowAdvertise="no">
-        <Condition Level="1">REMOVE ~= "ALL"</Condition>
-        <ComponentRef Id="RemoveFolderEx_VARFOLDER_Component"/>
-      </Feature>
 
       <Feature Id="VC120" Title="VC++ 2013" AllowAdvertise="no" Display="hidden"><MergeRef Id="MSM_VC120_CRT"/></Feature>
       <Feature Id="VC140" Title="VC++ 2015" AllowAdvertise="no" Display="hidden"><MergeRef Id="MSM_VC140_CRT"/></Feature>
@@ -182,8 +183,9 @@ xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
             <Directory Id="SALT_CONF_PKI_MINION_FOLDER" Name="minion" />
           </Directory>
         </Directory>
-        <!-- Declare bin and var folder for RemoveFolderEX remember pattern -->
+        <!-- Declare bin folder for RemoveFolderEX remember pattern -->
         <Directory Id="BINFOLDER"  Name="bin" />
+        <!-- Declare var folder for delete_VARFOLDER_CAX -->
         <Directory Id="VARFOLDER"  Name="var" />
       </Directory>
     </Directory>
@@ -207,18 +209,14 @@ xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
 
 
   <!--  Remove 'lifetime' data on uninstall. Lifetime data does not originate from the installer. -->
+  <!--  Wix uninstall include upgrades. Cannot be used for lifetime data that must persist on upgrade. -->
   <Fragment Id="RemoveFolderEx_Fragment">
     <?define RegDir="SOFTWARE\SaltStack\Salt-Minion"?>
     <?define RegVal_BINFOLDER="RememberForRemoveFolderExBINFOLDER"?>
-    <?define RegVal_VARFOLDER="RememberForRemoveFolderExVARFOLDER"?>
 
-    <Property Id="BINFOLDER">
+    <Property Id="BINFOLDER" Secure="yes">
       <RegistrySearch Root="HKLM" Key="$(var.RegDir)" Type="raw"
                 Id="BINFOLDER_REGSEARCH" Name="$(var.RegVal_BINFOLDER)" />
-    </Property>
-    <Property Id="VARFOLDER">
-      <RegistrySearch Root="HKLM" Key="$(var.RegDir)" Type="raw"
-                Id="VARFOLDER_REGSEARCH" Name="$(var.RegVal_VARFOLDER)" />
     </Property>
 
     <DirectoryRef Id='BINFOLDER'>
@@ -230,18 +228,5 @@ xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
         <RemoveFolder Id="BINFOLDER" On="uninstall"/>
       </Component>
     </DirectoryRef>
-
-    <DirectoryRef Id='VARFOLDER'>
-      <Component Id="RemoveFolderEx_VARFOLDER_Component" Guid="76b05a00-efbf-4e35-a442-6c76ccfd9c52">
-        <RegistryValue Root="HKLM" Key="$(var.RegDir)" Name="$(var.RegVal_VARFOLDER)"
-                Type="string" Value="[VARFOLDER]" KeyPath="yes"/>
-        <CreateFolder Directory="VARFOLDER"/>
-        <util:RemoveFolderEx Property="VARFOLDER" On="uninstall"/> <!-- Includes upgrade -->
-        <RemoveFolder Id="VARFOLDER" On="uninstall"/>
-      </Component>
-    </DirectoryRef>
-
   </Fragment>
-
-
 </Wix>

--- a/wix.d/MinionMSI/Product.wxs
+++ b/wix.d/MinionMSI/Product.wxs
@@ -104,14 +104,23 @@ xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
       Session.Property("nsis_uninstalldir") = Replace(Session.Property("NSIS_UNINSTALLSTRING"),"uninst.exe","")
     </CustomAction>
     <!-- Deferreds cannot access Session.Property but conditionally remove folders with lifetime data -->
+    <!-- CA are executed twice? On Error resume may help-->
     <CustomAction Id="delete_config_DECAX" Script="vbscript">
-Dim fso
+On error resume next
 Set fso = CreateObject("Scripting.FileSystemObject")
-if fso.FolderExists("c:\salt") then
+Set wshshell = CreateObject("Wscript.Shell")
+If fso.FileExists("C:\salt\ssm.exe") Then
+  wshshell.Run "C:\salt\ssm.exe stop   salt-minion", 0, True
+  wshshell.Run "cmd /c ping -n 5 127.0.0.1", 0, True
+  wshshell.Run "C:\salt\ssm.exe remove  salt-minion confirm", 0, True
+  wshshell.Run "cmd /c ping -n 5 127.0.0.1", 0, True
+End If
+If fso.FolderExists("C:\salt") Then
   fso.DeleteFolder "c:\salt"
-end if
+End If
     </CustomAction>
     <CustomAction Id="delete_VARFOLDER_DECAX" Script="vbscript">
+On Error Resume Next
 Dim fso
 Set fso = CreateObject("Scripting.FileSystemObject")
 if fso.FolderExists("c:\salt\var") then
@@ -119,14 +128,93 @@ if fso.FolderExists("c:\salt\var") then
 end if
     </CustomAction>
 
+    <CustomAction Id="capture_salt" Script="vbscript">
+' workaround for Salt-Minions that delete var folder
+Dim fso
+Set fso = CreateObject("Scripting.FileSystemObject")
+if fso.FolderExists("c:\salt\var\cache\salt\minion\extmods") then
+  ' destination must not exist
+  if fso.FolderExists("c:\salt_tmp_msi_wix") then
+    fso.DeleteFolder "c:\salt_tmp_msi_wix"
+  end if
+  ' parent of destination must exist
+  fso.CreateFolder "c:\salt_tmp_msi_wix"
+  fso.CopyFolder "c:\salt\var\cache\salt\minion\extmods", "c:\salt_tmp_msi_wix\extmods"
+end if
+    </CustomAction>
+    <CustomAction Id="restore_salt" Script="vbscript">
+' workaround for Salt-Minions that delete var folder
+Dim fso
+Set fso = CreateObject("Scripting.FileSystemObject")
+
+if fso.FolderExists("c:\salt_tmp_msi_wix\extmods") then
+  ' destination must not exist
+  if fso.FolderExists("c:\salt\var\cache\salt\minion\extmods") then
+    fso.DeleteFolder "c:\salt\var\cache\salt\minion\extmods"
+  end if
+  ' parent of destination must exist
+  if Not fso.FolderExists("c:\salt") then
+    fso.CreateFolder "c:\salt"
+  end if
+  if Not fso.FolderExists("c:\salt\var") then
+    fso.CreateFolder "c:\salt\var"
+  end if
+  if Not fso.FolderExists("c:\salt\var\cache") then
+    fso.CreateFolder "c:\salt\var\cache"
+  end if
+  if Not fso.FolderExists("c:\salt\var\cache\salt") then
+    fso.CreateFolder "c:\salt\var\cache\salt"
+  end if
+  if Not fso.FolderExists("c:\salt\var\cache\salt\minion") then
+    fso.CreateFolder "c:\salt\var\cache\salt\minion"
+  end if
+
+  fso.MoveFolder "c:\salt_tmp_msi_wix\extmods", "c:\salt\var\cache\salt\minion\extmods"
+  fso.DeleteFolder "c:\salt_tmp_msi_wix"
+end if
+    </CustomAction>
+    <CustomAction Id="hideSalt" Script="vbscript">
+On error resume next
+Set objShell = CreateObject("WScript.Shell")
+intReturn = objShell.Run("attrib.exe +H C:\salt" , 0, true)
+    </CustomAction>
+
+    <CustomAction Id="stopSalt" Script="vbscript">
+On error resume next
+Set objShell = CreateObject("WScript.Shell")
+objShell.Run "net stop salt-minion", 0, true
+objShell.Run "cmd /c ping -n 5 127.0.0.1", 0, True
+    </CustomAction>
+
+    <CustomAction Id="bruteforcedelete" Script="vbscript">
+On error resume next
+Set fso = CreateObject("Scripting.FileSystemObject")
+Set wshshell = CreateObject("Wscript.Shell")
+
+If fso.FileExists("C:\salt\ssm.exe") Then
+  wshshell.Run "C:\salt\ssm.exe stop salt-minion", 0, True
+  wshshell.Run "cmd /c ping -n 5 127.0.0.1", 0, True
+  wshshell.Run "C:\salt\ssm.exe remove salt-minion confirm", 0, True
+  wshshell.Run "cmd /c ping -n 5 127.0.0.1", 0, True
+End If
+If fso.FolderExists("C:\salt") Then
+  fso.DeleteFolder "c:\salt"
+End If
+    </CustomAction>
+
+
     <InstallUISequence>         <!-- * * * * * * * * * * * * * * * * * * Sequence with GUI * * * * * * * * * * * * * * * * *  -->
       <Custom Action="get_NSIS_uninstdir_IMCAX"    Before='LaunchConditions'         >NSIS_UNINSTALLSTRING</Custom>
       <Custom Action='ReadConfig_IMCAC'            Before='MigrateFeatureStates'     >NOT Installed</Custom>
+      <Custom Action='capture_salt'                 After='FindRelatedProducts'      >WIX_UPGRADE_DETECTED</Custom>  <!--only on upgrade, not on uninstall,-->
 
       <LaunchConditions After="AppSearch" /> <!-- Benefit is unclear. Was used when detecting MFC. Probably not needed. -->
     </InstallUISequence>
 
     <InstallExecuteSequence>     <!-- * * * * * * * * * * * * * * * * *  Sequence without GUI (silent, headless)  * * * * * *  -->
+      <!-- stopSalt because log file must be released -->
+      <Custom Action='stopSalt'                   Before='InstallValidate'          >1</Custom>
+
       <Custom Action='ReadConfig_IMCAC'            Before='MigrateFeatureStates'    >NOT Installed</Custom>
       <Custom Action='del_NSIS_DECAC'               After='InstallInitialize'       >nsis_uninst_waits_not</Custom>
       <Custom Action="uninst_NSIS1_DECAH"          Before='uninst_NSIS1_DECAX'     />
@@ -134,12 +222,18 @@ end if
       <Custom Action="uninst_NSIS2_DECAH"          Before='uninst_NSIS2_DECAX'     />
       <Custom Action="uninst_NSIS2_DECAX"          Before='ProcessComponents'       >nsis_uninst_waits_yes</Custom>
 
-      <Custom Action='delete_config_DECAX'         After='InstallFinalize'          >(REMOVE ~= "ALL") and REMOVE_CONFIG</Custom>
-      <Custom Action='delete_VARFOLDER_DECAX'      After='InstallFinalize'          >REMOVE ~= "ALL"</Custom>
+      <Custom Action='capture_salt'                After='FindRelatedProducts'      >WIX_UPGRADE_DETECTED</Custom>  <!--only on upgrade, not on uninstall -->
 
       <Custom Action='WriteConfig_CADH'
               Before='WriteConfig_DECAC'                                            >NOT Installed</Custom>
       <Custom Action='WriteConfig_DECAC'           After='WriteIniValues'           >NOT Installed</Custom>
+
+      <Custom Action='restore_salt'                After='PublishProduct'           >WIX_UPGRADE_DETECTED</Custom>  <!--only on upgrade, not on uninstall -->
+
+      <Custom Action='delete_VARFOLDER_DECAX'      After='InstallFinalize'          >REMOVE ~= "ALL"</Custom>
+      <Custom Action='delete_config_DECAX'         After='InstallFinalize'          >(REMOVE ~= "ALL") and REMOVE_CONFIG</Custom>
+      <Custom Action='bruteforcedelete'            After='InstallFinalize'          >(REMOVE ~= "ALL") and REMOVE_CONFIG</Custom>  <!--only on uninstall, not on upgrade? -->
+
 
       <!-- Optionally start the service  -->
       <StartServices Sequence="5900"><![CDATA[START_MINION = "1"]]></StartServices>

--- a/wix.d/MinionMSI/Product.wxs
+++ b/wix.d/MinionMSI/Product.wxs
@@ -103,14 +103,20 @@ xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
     <CustomAction Id="get_NSIS_uninstdir_IMCAX" Script="vbscript">
       Session.Property("nsis_uninstalldir") = Replace(Session.Property("NSIS_UNINSTALLSTRING"),"uninst.exe","")
     </CustomAction>
-    <!-- The most simple helper to conditionally remove a folder with lifetime data -->
-    <CustomAction Id="delete_config_CAX" Script="vbscript">
-      on error resume next
-      CreateObject("Scripting.FileSystemObject").GetFolder(Session.Property("CONFFOLDER")).Delete(True)
+    <!-- Deferreds cannot access Session.Property but conditionally remove folders with lifetime data -->
+    <CustomAction Id="delete_config_DECAX" Script="vbscript">
+Dim fso
+Set fso = CreateObject("Scripting.FileSystemObject")
+if fso.FolderExists("c:\salt") then
+  fso.DeleteFolder "c:\salt"
+end if
     </CustomAction>
-    <CustomAction Id="delete_VARFOLDER_CAX" Script="vbscript">
-      on error resume next
-      CreateObject("Scripting.FileSystemObject").GetFolder(Session.Property("VARFOLDER")).Delete(True)
+    <CustomAction Id="delete_VARFOLDER_DECAX" Script="vbscript">
+Dim fso
+Set fso = CreateObject("Scripting.FileSystemObject")
+if fso.FolderExists("c:\salt\var") then
+  fso.DeleteFolder "c:\salt\var"
+end if
     </CustomAction>
 
     <InstallUISequence>         <!-- * * * * * * * * * * * * * * * * * * Sequence with GUI * * * * * * * * * * * * * * * * *  -->
@@ -128,8 +134,8 @@ xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
       <Custom Action="uninst_NSIS2_DECAH"          Before='uninst_NSIS2_DECAX'     />
       <Custom Action="uninst_NSIS2_DECAX"          Before='ProcessComponents'       >nsis_uninst_waits_yes</Custom>
 
-      <Custom Action='delete_config_CAX'           After='RemoveFiles'              >(REMOVE ~= "ALL") and REMOVE_CONFIG</Custom>
-      <Custom Action='delete_VARFOLDER_CAX'        After='RemoveFiles'              >REMOVE ~= "ALL"</Custom>
+      <Custom Action='delete_config_DECAX'         After='InstallFinalize'          >(REMOVE ~= "ALL") and REMOVE_CONFIG</Custom>
+      <Custom Action='delete_VARFOLDER_DECAX'      After='InstallFinalize'          >REMOVE ~= "ALL"</Custom>
 
       <Custom Action='WriteConfig_CADH'
               Before='WriteConfig_DECAC'                                            >NOT Installed</Custom>
@@ -175,7 +181,7 @@ xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
 
 
   <Fragment>
-    <Directory Id="TARGETDIR" Name="SourceDir"> <!-- Outmost directory must be exactly this. Ramirez ch 1 p 25 -->
+    <Directory Id="TARGETDIR" Name="SourceDir">      <!-- Outmost directory must be exactly this. Ramirez ch 1 p 25 -->
       <Directory Id="INSTALLFOLDER" Name="salt" >
         <Directory Id="CONFFOLDER" Name="conf" >
           <Directory Id="MINION_D_CONF_FOLDER"  Name="minion.d" />
@@ -183,10 +189,8 @@ xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
             <Directory Id="SALT_CONF_PKI_MINION_FOLDER" Name="minion" />
           </Directory>
         </Directory>
-        <!-- Declare bin folder for RemoveFolderEX remember pattern -->
-        <Directory Id="BINFOLDER"  Name="bin" />
-        <!-- Declare var folder for delete_VARFOLDER_CAX -->
-        <Directory Id="VARFOLDER"  Name="var" />
+        <Directory Id="BINFOLDER"  Name="bin" />      <!-- For RemoveFolderEX remember pattern -->
+        <Directory Id="VARFOLDER"  Name="var" />      <!-- For delete_VARFOLDER_DECAX -->
       </Directory>
     </Directory>
 


### PR DESCRIPTION
# 
# WIP, DO NOT MERGE 

## Currently 
- uninstall with REMOVE_CONFIG=1 leaves files behind
  - The var folder is left over because the Feature was never installed.  I see no way to make RemoveFolderEx  optional.
  - The deferrred vbscripts do not delete folders because they cannot access Session.Property. [Details](http://sajojacob.com/2008/02/customactiondata-in-wix-with-deferred-custom-actions/)

## This PR
- Conditionally deletes fixed paths folders with vbscript after InstallFinalize
- Properly names deferred custom actions as _DECAX
- Abandons  RemoveFolderEx + Feature
- Adds another test-batch file 