### PR TITLE
Fixes

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -185,6 +185,10 @@ properties, and the current value of those properties:
 > msbuild msbuild.proj /t:help
 
 ### Other Notes
+msi conditions for Customm Actions in a table with install, uninstall, updgrade:
+- https://stackoverflow.com/a/17608049 
+
+
 Install sequences documentation:
 
 - [standard-actions-reference](https://docs.microsoft.com/en-us/windows/win32/msi/standard-actions-reference)

--- a/find-optional-modules/find-platform-tag-in-source-files.py
+++ b/find-optional-modules/find-platform-tag-in-source-files.py
@@ -1,0 +1,38 @@
+
+from __future__ import print_function
+import os
+
+SRCDIR = r'c:\git\salt\salt\grains'
+SRCDIR = r'c:\git\salt\salt\modules'
+
+def format_path(filehandle):
+    filehandle = filehandle.replace(SRCDIR+'\\', '')
+    filehandle = filehandle.replace('\\', '/')
+    return filehandle +'\n'
+
+
+def action(start_path):
+    withplatform = 0
+    withoutplatform = 0
+    for dirpath, _, filenames in os.walk(start_path):
+        for filename in filenames:
+            ffp = os.path.join(dirpath, filename)
+            if ffp.endswith('.py'):
+                goo = ""
+                with open(ffp, encoding="ascii", errors="ignore") as filehandle:
+                    for line in filehandle.readlines():
+                        if ":platform:" in line:
+                            goo = line.rstrip("\n")
+                            goo = goo.replace(":platform:","")
+                            continue
+            if len(goo) > 0:
+                print('{:25}   {}'.format(filename, goo))
+                withplatform += 1
+            else:
+                withoutplatform += 1
+    print('withplatform     {}'.format(withplatform))
+    print('withoutplatform  {}'.format(withoutplatform))
+
+action(SRCDIR)
+print("sss")
+

--- a/remove_orpahned_salt_components.bat
+++ b/remove_orpahned_salt_components.bat
@@ -1,0 +1,1 @@
+powershell -executionPolicy bypass -file remove_orpahned_salt_components.ps1

--- a/remove_orpahned_salt_components.ps1
+++ b/remove_orpahned_salt_components.ps1
@@ -1,0 +1,30 @@
+# The msi must remove all components.
+# But the msi uninstall log may contain
+#               disallowing uninstallation of component:   ......     since another client exists
+# After msi uninstall, run this to remove
+#
+# https://stackoverflow.com/questions/26739524/wix-toolset-complete-cleanup-after-disallowing-uninstallation-of-component-sin
+
+# S-1-5-18	Local System	A service account that is used by the operating system.
+$components = Get-ChildItem -Path HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Installer\UserData\S-1-5-18\Components\
+$removed = 0
+$unremoved = 0
+$each50 = 0
+foreach ($c in $components) {
+    foreach($p in $c.Property) {
+        $propValue = (Get-ItemProperty "Registry::$($c.Name)" -Name "$($p)")."$($p)"
+        if ($propValue -match '^C:\\salt\\') {
+            if ($each50++ -eq 50) {
+                Write-Output $propValue
+                $each50 = 0
+            }
+            Remove-Item "Registry::$($c.Name)" -Recurse
+            $removed++
+        } else {
+            $unremoved++
+        }
+    }
+}
+
+Write-Host "$($removed) Local System component(s) pointed to (manually removed) C:\salt files and removed, left $($unremoved) unremoved"
+

--- a/wix.d/MinionMSI/Product.wxs
+++ b/wix.d/MinionMSI/Product.wxs
@@ -70,15 +70,6 @@ xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
     <Property Id="MsiLogging"               Value="v"/>
     <Property Id="MSIUSEREALADMINDETECTION" Value="1"/>
     <Property Id="WIXUI_INSTALLDIR"         Value="INSTALLFOLDER"/>
-    <DirectoryRef Id="TARGETDIR">
-        <Component Id="SaltNssmRegistryEntries" Guid="fcb947ff-016b-45f8-a7d0-0a98df0d0537">
-            <RegistryKey Root="HKLM"
-                         Key="System\CurrentControlSet\Services\salt-minion\Parameters"
-                         ForceDeleteOnUninstall='yes'>
-                <RegistryValue Name="AppRestartDelay"    Value="60000"  Type="integer"/>
-            </RegistryKey>
-        </Component>
-    </DirectoryRef>
 
     <!-- Search previous NSIS installation.
          Assume NSIS always (32 and 64 bit Salt-minion) writes into the 32bit WoW registry -->
@@ -266,7 +257,6 @@ End If
     </DirectoryRef>
 
     <Feature Id="ProductFeature" Title="Minion" Level="1">
-      <ComponentRef Id="SaltNssmRegistryEntries" />
       <ComponentGroupRef Id="ProductComponents" />
       <ComponentRef      Id="RemoveFolderEx_BINFOLDER_Component" /> <!-- On uninstall and upgrade -->
 

--- a/wix.d/MinionMSI/Product.wxs
+++ b/wix.d/MinionMSI/Product.wxs
@@ -114,7 +114,7 @@ xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
     </CustomAction>
     <!-- Deferreds cannot access Session.Property but conditionally remove folders with lifetime data -->
     <!-- CA are executed twice? On Error resume may help-->
-    <CustomAction Id="delete_config_DECAX" Script="vbscript">
+    <CustomAction Id="delete_excl_config_DECAX" Script="vbscript">
 On error resume next
 Set fso = CreateObject("Scripting.FileSystemObject")
 Set wshshell = CreateObject("Wscript.Shell")
@@ -124,8 +124,12 @@ If fso.FileExists("C:\salt\ssm.exe") Then
   wshshell.Run "C:\salt\ssm.exe remove  salt-minion confirm", 0, True
   wshshell.Run "cmd /c ping -n 5 127.0.0.1", 0, True
 End If
-If fso.FolderExists("C:\salt") Then
-  fso.DeleteFolder "c:\salt"
+If fso.FileExists("C:\salt\ssm.exe") Then
+  fso.DeleteFile "c:\salt\ssm.exe"
+End If
+fso.DeleteFile "c:\salt\salt*"
+If fso.FolderExists("C:\salt\bin") Then
+  fso.DeleteFolder "c:\salt\bin"
 End If
     </CustomAction>
     <CustomAction Id="delete_VARFOLDER_DECAX" Script="vbscript">
@@ -195,7 +199,7 @@ objShell.Run "net stop salt-minion", 0, true
 objShell.Run "cmd /c ping -n 5 127.0.0.1", 0, True
     </CustomAction>
 
-    <CustomAction Id="bruteforcedelete" Script="vbscript">
+    <CustomAction Id="delete_incl_config_DECAX" Script="vbscript">
 On error resume next
 Set fso = CreateObject("Scripting.FileSystemObject")
 Set wshshell = CreateObject("Wscript.Shell")
@@ -239,8 +243,8 @@ End If
       <Custom Action='restore_salt'                After='PublishProduct'           >WIX_UPGRADE_DETECTED</Custom>  <!--only on upgrade, not on uninstall -->
 
       <Custom Action='delete_VARFOLDER_DECAX'      After='InstallFinalize'          >REMOVE ~= "ALL"</Custom>
-      <Custom Action='delete_config_DECAX'         After='InstallFinalize'          >(REMOVE ~= "ALL") and REMOVE_CONFIG</Custom>
-      <Custom Action='bruteforcedelete'            After='InstallFinalize'          >(REMOVE ~= "ALL") and REMOVE_CONFIG</Custom>  <!--only on uninstall, not on upgrade? -->
+      <Custom Action='delete_excl_config_DECAX'    After='InstallFinalize'          >(REMOVE ~= "ALL") and (NOT REMOVE_CONFIG)</Custom>
+      <Custom Action='delete_incl_config_DECAX'    After='InstallFinalize'          >(REMOVE ~= "ALL") and REMOVE_CONFIG</Custom>  <!--only on uninstall, not on upgrade? -->
 
 
       <!-- Optionally start the service  -->

--- a/wix.d/MinionMSI/service.wxs
+++ b/wix.d/MinionMSI/service.wxs
@@ -16,7 +16,6 @@
           <RegistryValue Type="expandable" Name="AppDirectory"        Value="[INSTALLFOLDER]bin" />
           <RegistryValue Type="expandable" Name="Application"         Value="[INSTALLFOLDER]bin\python.exe" />
           <RegistryValue Type="expandable" Name="AppParameters"       Value="[INSTALLFOLDER]bin\Scripts\salt-minion -c [INSTALLFOLDER]conf -l quiet" />
-          <RegistryValue Type="expandable" Name="AppEnvironmentExtra" Value="PYTHONHOME=" />
         </RegistryKey>
         <RegistryKey Root="HKLM" Key="System\CurrentControlSet\Services\salt-minion\Parameters\AppExit">
           <RegistryValue Type="string" Value="Restart" />

--- a/wix.d/MinionMSI/service.wxs
+++ b/wix.d/MinionMSI/service.wxs
@@ -11,16 +11,18 @@
         <ServiceControl Id="SaltMinionServiceControlNoStart" Name="salt-minion" Remove="uninstall" Stop="both" Start="install" Wait="yes">
           <ServiceArgument />
         </ServiceControl>
-        <RegistryKey Root="HKLM" Key="System\CurrentControlSet\Services\salt-minion\Parameters">
-          <RegistryValue Type="expandable" Name="AppDirectory"         Value="[INSTALLFOLDER]bin" />
-          <RegistryValue Type="expandable" Name="Application"          Value="[INSTALLFOLDER]bin\python.exe" />
-          <RegistryValue Type="expandable" Name="AppParameters"        Value="-E -s [INSTALLFOLDER]bin\Scripts\salt-minion -c [INSTALLFOLDER]conf -l quiet" />
-          <RegistryValue Type="integer"    Name="AppStopMethodConsole" Value="24000" />
-          <RegistryValue Type="integer"    Name="AppStopMethodWindow"  Value="2000" />
-          <RegistryValue Type="integer"    Name="AppRestartDelay"      Value="60000" />
-        </RegistryKey>
-        <RegistryKey Root="HKLM" Key="System\CurrentControlSet\Services\salt-minion\Parameters\AppExit">
-          <RegistryValue Type="string" Value="Restart" />
+        <RegistryKey Root="HKLM" Key="System\CurrentControlSet\Services\salt-minion">
+          <RegistryKey Key="Parameters">
+            <RegistryValue Type="expandable" Name="AppDirectory"         Value="[INSTALLFOLDER]bin" />
+            <RegistryValue Type="expandable" Name="Application"          Value="[INSTALLFOLDER]bin\python.exe" />
+            <RegistryValue Type="expandable" Name="AppParameters"        Value="-E -s [INSTALLFOLDER]bin\Scripts\salt-minion -c [INSTALLFOLDER]conf -l quiet" />
+            <RegistryValue Type="integer"    Name="AppStopMethodConsole" Value="24000" />
+            <RegistryValue Type="integer"    Name="AppStopMethodWindow"  Value="2000" />
+            <RegistryValue Type="integer"    Name="AppRestartDelay"      Value="60000" />
+            <RegistryKey Key="AppExit">
+              <RegistryValue Type="string" Value="Restart" />
+            </RegistryKey>
+          </RegistryKey>
         </RegistryKey>
       </Component>
     </ComponentGroup>

--- a/wix.d/MinionMSI/service.wxs
+++ b/wix.d/MinionMSI/service.wxs
@@ -7,7 +7,6 @@
         <ServiceInstall Account="LocalSystem" ErrorControl="normal" Name="salt-minion" Start="auto" Type="ownProcess" Vital="yes"
           Description="Salt Minion from saltstack.com" DisplayName="Salt Minion" Id="SaltMinionServiceInstall">
           <ServiceConfig OnInstall="yes" OnReinstall="yes" DelayedAutoStart="no" />
-          <ServiceDependency Id="nsi" />
         </ServiceInstall>
         <ServiceControl Id="SaltMinionServiceControlNoStart" Name="salt-minion" Remove="uninstall" Stop="both" Start="install" Wait="yes">
           <ServiceArgument />

--- a/wix.d/MinionMSI/service.wxs
+++ b/wix.d/MinionMSI/service.wxs
@@ -4,11 +4,28 @@
     <ComponentGroup Id="service">
       <Component Id="cmp906378FA53882935FD2EC0CC58D32FAC" Directory="INSTALLFOLDER" Guid="{E27F3682-194D-4CC2-9F9B-F3E1D53ADCDB}">
         <File Id="fil055DB09E328331BF0202C29D7483905C" KeyPath="yes" Source="$(var.dist)\bin\ssm.exe" />
-        <ServiceInstall Account="LocalSystem" ErrorControl="normal" Name="salt-minion" Start="auto" Type="ownProcess" Vital="yes"
-          Description="Salt Minion from saltstack.com" DisplayName="Salt Minion" Id="SaltMinionServiceInstall">
-          <ServiceConfig OnInstall="yes" OnReinstall="yes" DelayedAutoStart="no" />
+        <ServiceInstall
+          Account="LocalSystem"
+          ErrorControl="normal"
+          Name="salt-minion"
+          Start="auto"
+          Type="ownProcess"
+          Vital="yes"
+          Description="Salt Minion from saltstack.com"
+          DisplayName="Salt Minion"
+          Id="SaltMinionServiceInstall">
+          <ServiceConfig
+            OnInstall="yes"
+            OnReinstall="yes"
+            DelayedAutoStart="no" />
         </ServiceInstall>
-        <ServiceControl Id="SaltMinionServiceControlNoStart" Name="salt-minion" Remove="uninstall" Stop="both" Start="install" Wait="yes">
+        <ServiceControl
+          Id="SaltMinionServiceControl"
+          Name="salt-minion"
+          Remove="uninstall"
+          Stop="both"
+          Start="install"
+          Wait="yes">
           <ServiceArgument />
         </ServiceControl>
         <RegistryKey Root="HKLM" Key="System\CurrentControlSet\Services\salt-minion">

--- a/wix.d/MinionMSI/service.wxs
+++ b/wix.d/MinionMSI/service.wxs
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
+  xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
   <Fragment>
     <ComponentGroup Id="service">
       <Component Id="cmp906378FA53882935FD2EC0CC58D32FAC" Directory="INSTALLFOLDER" Guid="{E27F3682-194D-4CC2-9F9B-F3E1D53ADCDB}">
-        <File Id="fil055DB09E328331BF0202C29D7483905C" KeyPath="yes" Source="$(var.dist)\bin\ssm.exe" />
+        <File Id="ssm.exe" KeyPath="yes" Source="$(var.dist)\bin\ssm.exe" />
         <ServiceInstall
           Account="LocalSystem"
           ErrorControl="normal"
@@ -12,12 +13,12 @@
           Type="ownProcess"
           Vital="yes"
           Description="Salt Minion from saltstack.com"
-          DisplayName="Salt Minion"
+          DisplayName="salt-minion"
           Id="SaltMinionServiceInstall">
-          <ServiceConfig
-            OnInstall="yes"
-            OnReinstall="yes"
-            DelayedAutoStart="no" />
+          <util:ServiceConfig
+            FirstFailureActionType="none"
+            SecondFailureActionType="none"
+            ThirdFailureActionType="none" />
         </ServiceInstall>
         <ServiceControl
           Id="SaltMinionServiceControl"
@@ -28,6 +29,11 @@
           Wait="yes">
           <ServiceArgument />
         </ServiceControl>
+        <CreateFolder />
+        <util:EventSource
+          Log="Application"
+          Name="nssm"
+          EventMessageFile="[#ssm.exe]" />
         <RegistryKey Root="HKLM" Key="System\CurrentControlSet\Services\salt-minion">
           <RegistryKey Key="Parameters">
             <RegistryValue Type="expandable" Name="AppDirectory"         Value="[INSTALLFOLDER]bin" />

--- a/wix.d/MinionMSI/service.wxs
+++ b/wix.d/MinionMSI/service.wxs
@@ -13,9 +13,12 @@
           <ServiceArgument />
         </ServiceControl>
         <RegistryKey Root="HKLM" Key="System\CurrentControlSet\Services\salt-minion\Parameters">
-          <RegistryValue Type="expandable" Name="AppDirectory"        Value="[INSTALLFOLDER]bin" />
-          <RegistryValue Type="expandable" Name="Application"         Value="[INSTALLFOLDER]bin\python.exe" />
-          <RegistryValue Type="expandable" Name="AppParameters"       Value="[INSTALLFOLDER]bin\Scripts\salt-minion -c [INSTALLFOLDER]conf -l quiet" />
+          <RegistryValue Type="expandable" Name="AppDirectory"         Value="[INSTALLFOLDER]bin" />
+          <RegistryValue Type="expandable" Name="Application"          Value="[INSTALLFOLDER]bin\python.exe" />
+          <RegistryValue Type="expandable" Name="AppParameters"        Value="-E -s [INSTALLFOLDER]bin\Scripts\salt-minion -c [INSTALLFOLDER]conf -l quiet" />
+          <RegistryValue Type="integer"    Name="AppStopMethodConsole" Value="24000" />
+          <RegistryValue Type="integer"    Name="AppStopMethodWindow"  Value="2000" />
+          <RegistryValue Type="integer"    Name="AppRestartDelay"      Value="60000" />
         </RegistryKey>
         <RegistryKey Root="HKLM" Key="System\CurrentControlSet\Services\salt-minion\Parameters\AppExit">
           <RegistryValue Type="string" Value="Restart" />

--- a/wix.d/MinionMSI/servicePython.wxs
+++ b/wix.d/MinionMSI/servicePython.wxs
@@ -1,12 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
+  xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
   <Fragment>
     <Component        Id="servicePython" Directory="BINFOLDER" Guid="51713960-fbe7-4e87-9472-66e3c18f76cd">
       <File           Source="$(var.dist)\bin\python.exe"  KeyPath="yes"/>
       <ServiceInstall Name="salt-minion"  DisplayName="Salt Minion"  Description="Salt Minion from saltstack.com"
                       Arguments="[BINFOLDER]Scripts\salt-minion -c [INSTALLFOLDER]conf -l quiet"
                       Account="LocalSystem"  ErrorControl="normal" Start="auto"  Type="ownProcess"  Vital="yes" >
-        <ServiceConfig OnInstall="yes" OnReinstall="yes" DelayedAutoStart="no" />
+        <util:ServiceConfig
+          FirstFailureActionType="none"
+          SecondFailureActionType="none"
+          ThirdFailureActionType="none" />
       </ServiceInstall>
       <!-- 
         Stop the service on both install (upgrade) and uninstall. 


### PR DESCRIPTION
Fixes 
- Removes `C:\salt\bin` on uninstall also without option `REMOVE_CONFIG=1` 
- [Removes nssm setting AppEnvironmentExtra, as in PR 42571](https://github.com/markuskramerIgitt/salt-windows-msi/issues/82)
- Adds missing NSSM Parameters
- Remove false NSSM Parameters
- Using util:ServiceConfig to reduce warnings.
- Using util:EventSource to create a event source . 