### PR TITLE
Introducing ROOTDIR

### DIFF
--- a/Product-discover-files-config.xsl
+++ b/Product-discover-files-config.xsl
@@ -29,7 +29,7 @@ xmlns:msxsl="urn:schemas-microsoft-com:xslt" exclude-result-prefixes="msxsl">
 </xsl:template>
 
 
-<!-- This is the XSL madness copied for the case you harvest not CONFIGDIR but CONFDIR -->
+<!-- This is the XSL madness copied for the case you harvest not ROOTDIR but CONFDIR -->
 <!--key to detect minion file -->
 <!--                                     ends-with  WORKAROUND  substring(A,                length(A)                      - length(B) + 1)    -->
 <xsl:key name="conf_minion_key2" match="wix:Component['minion' = substring(wix:File/@Source, string-length(wix:File/@Source) - 5)]" use="@Id"/>

--- a/Product.wxs
+++ b/Product.wxs
@@ -82,6 +82,20 @@ IMCAC - Immediate Custom Action - It's immediate
     <SetProperty Id="REMOVE_CONFIG" Value='1'               Before="LaunchConditions">MINION_CONFIG</SetProperty>
 
 
+    <!-- Search for old config minion file -->
+    <Property Id="OLD_CONF_EXISTS">
+      <DirectorySearch Id="conf_old" Path="C:\salt\conf">
+        <FileSearch Name="minion"/>
+      </DirectorySearch>
+    </Property>
+
+    <!-- Search for new config minion file -->
+    <Property Id="NEW_CONF_EXISTS">
+      <DirectorySearch Id="conf_new" Path="C:\ProgramData\Salt Project\Salt\conf">
+        <FileSearch Name="minion"/>
+      </DirectorySearch>
+    </Property>
+
     <!-- Search registry for previous msi and Nullsoft install dirs, assumes Nullsoft writes to 32bit registry -->
     <Property Id="PREVIOUS_ROOTDIR">
       <!-- Currently unused -->

--- a/Product.wxs
+++ b/Product.wxs
@@ -82,9 +82,9 @@ IMCAC - Immediate Custom Action - It's immediate
     <SetProperty Id="REMOVE_CONFIG" Value='1'               Before="LaunchConditions">MINION_CONFIG</SetProperty>
 
 
-    <!-- Search registry for previous msi and Nullsoft install dirs, assumes Nullsoft writes to 32bit registry-->
-    <Property Id="PCONFIGDIR">
-      <!-- C:\ProgramData\Salt Project\Salt -->
+    <!-- Search registry for previous msi and Nullsoft install dirs, assumes Nullsoft writes to 32bit registry -->
+    <Property Id="PREVIOUS_ROOTDIR">
+      <!-- Currently unused -->
       <RegistrySearch Root="HKLM" Key="SOFTWARE\$(var.MANUFACTURER)\$(var.PRODUCTDIR)" Name="root_dir" Win64="$(var.WIN64)" Type="raw" Id="rsc"/>
       <RegistrySearch Root="HKLM" Key="SOFTWARE\$(var.MANUFACTURER)\$(var.PRODUCTDIR)" Name="root_dir" Win64="no"           Type="raw" Id="rsc_nullsoft"/>
     </Property>
@@ -98,7 +98,7 @@ IMCAC - Immediate Custom Action - It's immediate
     <Component Id="register_dirs" Directory="TARGETDIR">
       <RegistryKey Root="HKLM" Key="SOFTWARE\$(var.MANUFACTURER)\$(var.PRODUCTDIR)">
         <RegistryValue Name="install_dir" Value="[INSTALLDIR]" Type="string"/>
-        <RegistryValue Name="root_dir"    Value="[CONFIGDIR]"  Type="string"/>
+        <RegistryValue Name="root_dir"    Value="[ROOTDIR]"    Type="string"/>
       </RegistryKey>
     </Component>
     <Component Id="register_remove_config" Directory="TARGETDIR">
@@ -204,8 +204,8 @@ IMCAC - Immediate Custom Action - It's immediate
     <!-- Custom Action Data Helper for deferred custom actions  -->
     <!-- master and id must be named like in YAML configuration -->
     <!-- Send all this stuff down to the sandbox -->
-    <CustomAction Id="WriteConfig_CADH"  Property="WriteConfig_DECAC"  Value="master=[MASTER];id=[MINION_ID];MOVE_CONF=[MOVE_CONF];sourcedir=[SOURCEDIR];INSTALLDIR=[INSTALLDIR];CONFIGDIR=[CONFIGDIR];CONFDIR=[CONFDIR];config_type=[CONFIG_TYPE];MINION_CONFIG=[MINION_CONFIG];custom_config=[CUSTOM_CONFIG];" />
-    <CustomAction Id="DeleteConfig_CADH" Property="DeleteConfig_DECAC" Value="REMOVE_CONFIG=[REMOVE_CONFIG];INSTALLDIR=[INSTALLDIR];CONFIGDIR=[CONFIGDIR];" />
+    <CustomAction Id="WriteConfig_CADH"  Property="WriteConfig_DECAC"  Value="master=[MASTER];id=[MINION_ID];MOVE_CONF=[MOVE_CONF];sourcedir=[SOURCEDIR];INSTALLDIR=[INSTALLDIR];ROOTDIR=[ROOTDIR];CONFDIR=[CONFDIR];config_type=[CONFIG_TYPE];MINION_CONFIG=[MINION_CONFIG];custom_config=[CUSTOM_CONFIG];" />
+    <CustomAction Id="DeleteConfig_CADH" Property="DeleteConfig_DECAC" Value="REMOVE_CONFIG=[REMOVE_CONFIG];INSTALLDIR=[INSTALLDIR];ROOTDIR=[ROOTDIR];" />
 
 
     <!-- Prevent downgrade -->
@@ -238,7 +238,7 @@ IMCAC - Immediate Custom Action - It's immediate
       <ComponentGroupRef Id="DiscoveredConfigFiles" />
       <ComponentGroupRef Id="service" />
       <ComponentRef Id="INSTALLDIR_Permissions" />
-      <ComponentRef Id="CONFIGDIR_Permissions" />
+      <ComponentRef Id="ROOTDIR_Permissions" />
       <ComponentRef Id="register_dirs"/>
       <ComponentRef Id="register_remove_config"/>
     </ComponentGroup>
@@ -319,16 +319,16 @@ IMCAC - Immediate Custom Action - It's immediate
         </Directory>
       </Directory>
       <Directory Id="CommonAppDataFolder">                        <!-- C:\ProgramData -->
-        <Directory Id="configparent" Name="$(var.MANUFACTURER)">
-          <Directory Id="CONFIGDIR" Name="$(var.PRODUCTDIR)">
+        <Directory Id="rootparent" Name="$(var.MANUFACTURER)">
+          <Directory Id="ROOTDIR" Name="$(var.PRODUCTDIR)">
             <Directory Id="CONFDIR" Name="conf" />
           </Directory>
         </Directory>
       </Directory>
     </Directory>
-    <!-- Set CONFIGDIR to C:\salt unless MOVE_CONF (only before install sequence)  -->
-    <SetDirectory Id="CONFIGDIR" Value="C:\salt\"      Sequence="execute">not MOVE_CONF</SetDirectory>
-    <SetDirectory Id="CONFDIR"   Value="C:\salt\conf\" Sequence="execute">not MOVE_CONF</SetDirectory>
+    <!-- Set ROOTDIR to C:\salt unless MOVE_CONF (only before install sequence)  -->
+    <SetDirectory Id="ROOTDIR" Value="C:\salt\"      Sequence="execute">not MOVE_CONF</SetDirectory>
+    <SetDirectory Id="CONFDIR" Value="C:\salt\conf\" Sequence="execute">not MOVE_CONF</SetDirectory>
     <!-- Set ownership to 'Localized qualified name of the Administrators group' -->
     <PropertyRef Id="WIX_ACCOUNT_ADMINISTRATORS" />
     <Component Id="INSTALLDIR_Permissions"  Directory="INSTALLDIR" Guid="B30E119F-0286-4453-8AB7-C6E916FA2843">
@@ -336,7 +336,7 @@ IMCAC - Immediate Custom Action - It's immediate
         <Permission User="[WIX_ACCOUNT_ADMINISTRATORS]" GenericAll="yes" TakeOwnership="yes" />
       </CreateFolder>
     </Component>
-    <Component Id="CONFIGDIR_Permissions"   Directory="CONFIGDIR" Guid="84554438-6807-4d92-b602-7fce831b01a3">
+    <Component Id="ROOTDIR_Permissions" Directory="ROOTDIR" Guid="84554438-6807-4d92-b602-7fce831b01a3">
       <CreateFolder>
         <Permission User="[WIX_ACCOUNT_ADMINISTRATORS]" GenericAll="yes" TakeOwnership="yes" />
       </CreateFolder>
@@ -368,7 +368,7 @@ IMCAC - Immediate Custom Action - It's immediate
           <RegistryKey Key="Parameters">
             <RegistryValue Type="expandable" Name="AppDirectory"         Value="[INSTALLDIR]bin" />
             <RegistryValue Type="expandable" Name="Application"          Value="[INSTALLDIR]bin\python.exe" />
-            <RegistryValue Type="expandable" Name="AppParameters"        Value='-E -s "[INSTALLDIR]bin\Scripts\salt-minion" -c "[CONFIGDIR]conf" -l quiet' />
+            <RegistryValue Type="expandable" Name="AppParameters"        Value='-E -s "[INSTALLDIR]bin\Scripts\salt-minion" -c "[CONFDIR]" -l quiet' />
             <RegistryValue Type="integer"    Name="AppStopMethodConsole" Value="24000" />
             <RegistryValue Type="integer"    Name="AppStopMethodWindow"  Value="2000" />
             <RegistryValue Type="integer"    Name="AppRestartDelay"      Value="60000" />
@@ -384,7 +384,7 @@ IMCAC - Immediate Custom Action - It's immediate
       <Component        Id="servicec1" Directory="INSTALLDIR" Guid="51713960-fbe7-4e87-9472-66e3c18f76cd">
         <File           Source="$(var.DISCOVER_INSTALLDIR)\bin\python.exe"  KeyPath="yes"/>
         <ServiceInstall Name="salt-minion"  DisplayName="Salt Minion"  Description="Salt Minion from saltstack.com"
-                        Arguments="[INSTALLDIR]\bin\Scripts\salt-minion -c [INSTALLDIR]conf -l quiet"
+                        Arguments="[INSTALLDIR]\bin\Scripts\salt-minion -c [CONFDIR] -l quiet"
                         Account="LocalSystem"  ErrorControl="normal" Start="auto"  Type="ownProcess"  Vital="yes" >
           <util:ServiceConfig
             FirstFailureActionType="none"

--- a/Product.wxs
+++ b/Product.wxs
@@ -342,9 +342,9 @@ IMCAC - Immediate Custom Action - It's immediate
         </Directory>
       </Directory>
     </Directory>
-    <!-- Set ROOTDIR to C:\salt unless MOVE_CONF (only before install sequence)  -->
-    <SetDirectory Id="ROOTDIR" Value="C:\salt\"      Sequence="execute">not MOVE_CONF</SetDirectory>
-    <SetDirectory Id="CONFDIR" Value="C:\salt\conf\" Sequence="execute">not MOVE_CONF</SetDirectory>
+    <!-- Set ROOTDIR to C:\salt if OLD_CONF_EXISTS and not MOVE_CONF (only before install sequence)  -->
+    <SetDirectory Id="ROOTDIR" Value="C:\salt\"      Sequence="execute">OLD_CONF_EXISTS and (not MOVE_CONF)</SetDirectory>
+    <SetDirectory Id="CONFDIR" Value="C:\salt\conf\" Sequence="execute">OLD_CONF_EXISTS and (not MOVE_CONF)</SetDirectory>
     <!-- Set ownership to 'Localized qualified name of the Administrators group' -->
     <PropertyRef Id="WIX_ACCOUNT_ADMINISTRATORS" />
     <Component Id="INSTALLDIR_Permissions"  Directory="INSTALLDIR" Guid="B30E119F-0286-4453-8AB7-C6E916FA2843">

--- a/Product.wxs
+++ b/Product.wxs
@@ -76,8 +76,6 @@ IMCAC - Immediate Custom Action - It's immediate
 
     <!-- Allow command line alias for Property  -->
     <SetProperty Id="INSTALLDIR"  Value='[INSTALLFOLDER]'   Before="LaunchConditions">INSTALLFOLDER</SetProperty>
-    <!-- MINION_CONFIG implies MOVE_CONF  -->
-    <SetProperty Id="MOVE_CONF"     Value='1'               Before="LaunchConditions">MINION_CONFIG</SetProperty>
     <!-- MINION_CONFIG implies REMOVE_CONFIG  -->
     <SetProperty Id="REMOVE_CONFIG" Value='1'               Before="LaunchConditions">MINION_CONFIG</SetProperty>
 

--- a/Product.wxs
+++ b/Product.wxs
@@ -296,8 +296,10 @@ IMCAC - Immediate Custom Action - It's immediate
         <Control Id="MinionId"     Type="Edit"       X="30"  Y="100" Width="190" Height="15" Property="MINION_ID" />
         <Control Id="StartService" Type="CheckBox"   X="20"  Y="140" Width="280" Height="15" Property="START_MINION"       CheckBoxValue="1" Text="&amp;Start salt-minion service immediately"/>
         <Control Id="HideInARP"    Type="CheckBox"   X="20"  Y="155" Width="280" Height="15" Property="ARPSYSTEMCOMPONENT" CheckBoxValue="1" Text="&amp;Hide in 'Programs and Features'"/>
-        <Control Id="move_conf"    Type="CheckBox"   X="20"  Y="170" Width="280" Height="15" Property="MOVE_CONF"          CheckBoxValue="1" Text="&amp;Move configuration from 'C:\salt' to 'C:\ProgramData\Salt Project'."/>
-        <Control Id="remove_conf"  Type="CheckBox"   X="20"  Y="185" Width="280" Height="15" Property="REMOVE_CONFIG"      CheckBoxValue="1" Text="&amp;Remove configuration on uninstall"/>
+        <Control Id="remove_conf"  Type="CheckBox"   X="20"  Y="170" Width="280" Height="15" Property="REMOVE_CONFIG"      CheckBoxValue="1" Text="&amp;Remove configuration on uninstall"/>
+        <Control Id="move_conf"    Type="CheckBox"   X="20"  Y="185" Width="280" Height="15" Property="MOVE_CONF"          CheckBoxValue="1" Text="&amp;Move configuration from 'C:\salt' to 'C:\ProgramData\Salt Project'.">
+          <Condition Action="hide">not OLD_CONF_EXISTS</Condition>
+        </Control>
 
         <Control Id="Back"         Type="PushButton" X="180" Y="243" Width="56"  Height="17"               Text="!(loc.WixUIBack)" />
         <Control Id="Next"         Type="PushButton" X="236" Y="243" Width="56"  Height="17" Default="yes" Text="!(loc.WixUINext)" />

--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ If `MINION_CONFIG` is given:
 - All prior configuration is deleted:
   - all `minion.d\*.conf` files
   - the `minion_id` file
-- Implies `MOVE_CONF=1`: configuration is written to `%ProgramData%`.
 - Implies `REMOVE_CONFIG=1`: uninstall will remove all configuration.
 
 Example `MINION_CONFIG="master: Anna^id: Ben"` results in:

--- a/build.ps1
+++ b/build.ps1
@@ -66,7 +66,7 @@ $PRODUCTFILE    = "Salt-Minion-$displayversion"
 $PRODUCTDIR     = "Salt"
 $VERSION        = $internalversion
 $DISCOVER_INSTALLDIR = "..\salt\pkg\windows\buildenv", "..\salt\pkg\windows\buildenv"
-$DISCOVER_CONFIGDIR  = "..\salt\pkg\windows\buildenv\conf"
+$DISCOVER_CONFDIR    = "..\salt\pkg\windows\buildenv\conf"
 
 # MSBUild needed to compile C#
 If ( (Get-CimInstance Win32_OperatingSystem).OSArchitecture -eq "64-bit" ) {
@@ -137,7 +137,7 @@ CheckExitCode
 
 Write-Host -ForegroundColor Yellow "Discovering  INSTALLDIR from $($DISCOVER_INSTALLDIR[$i]) to *$($ARCHITECTURE[$i])*.wxs"
 # move conf folder up one dir because it must not be discoverd twice and xslt is difficult
-Move-Item $DISCOVER_CONFIGDIR $DISCOVER_CONFIGDIR\..\..\temporarily_moved_conf_folder
+Move-Item $DISCOVER_CONFDIR $DISCOVER_CONFDIR\..\..\temporarily_moved_conf_folder
 # https://wixtoolset.org/documentation/manual/v3/overview/heat.html
 # -cg <ComponentGroupName> Component group name (cannot contain spaces e.g -cg MyComponentGroup).
 # -sfrag   Suppress generation of fragments for directories and components.
@@ -154,13 +154,13 @@ Move-Item $DISCOVER_CONFIGDIR $DISCOVER_CONFIGDIR\..\..\temporarily_moved_conf_f
    -cg DiscoveredBinaryFiles -var var.DISCOVER_INSTALLDIR `
    -dr INSTALLDIR -t Product-discover-files.xsl `
    -nologo -indent 1 -gg -sfrag -sreg -srd -ke -template fragment
-Move-Item $DISCOVER_CONFIGDIR\..\..\temporarily_moved_conf_folder $DISCOVER_CONFIGDIR
+Move-Item $DISCOVER_CONFDIR\..\..\temporarily_moved_conf_folder $DISCOVER_CONFDIR
 CheckExitCode
 
 # Config shall remain, so delete all Guid (TODO)
-Write-Host -ForegroundColor Yellow "Discovering  CONFDIR    from $DISCOVER_CONFIGDIR to *.wxs"
-& "$($ENV:WIX)bin\heat" dir "$DISCOVER_CONFIGDIR" -out "Product-discovered-files-config.wxs" `
-   -cg DiscoveredConfigFiles -var var.DISCOVER_CONFIGDIR `
+Write-Host -ForegroundColor Yellow "Discovering  CONFDIR    from $DISCOVER_CONFDIR to *.wxs"
+& "$($ENV:WIX)bin\heat" dir "$DISCOVER_CONFDIR" -out "Product-discovered-files-config.wxs" `
+   -cg DiscoveredConfigFiles -var var.DISCOVER_CONFDIR `
    -dr CONFDIR -t Product-discover-files-config.xsl `
    -nologo -indent 1 -gg -sfrag -sreg -srd -ke -template fragment
 CheckExitCode
@@ -177,7 +177,7 @@ Write-Host -ForegroundColor Yellow "Compiling    *.wxs to $($ARCHITECTURE[$i]) *
     -dDisplayVersion="$displayversion" `
     -dInternalVersion="$internalversion" `
     -dDISCOVER_INSTALLDIR="$($DISCOVER_INSTALLDIR[$i])" `
-    -dDISCOVER_CONFIGDIR="$DISCOVER_CONFIGDIR" `
+    -dDISCOVER_CONFDIR="$DISCOVER_CONFDIR" `
     -ext "$($ENV:WIX)bin\WixUtilExtension.dll" `
     -ext "$($ENV:WIX)bin\WixUIExtension.dll" `
     -ext "$($ENV:WIX)bin\WixNetFxExtension.dll" `
@@ -189,7 +189,7 @@ Write-Host -ForegroundColor Yellow "Linking      $PRODUCT-$VERSION-$($ARCH_AKA[$
 & "$($ENV:WIX)bin\light"  -nologo `
     -out "$pwd\$PRODUCTFILE-Py$pythonversion-$($ARCH_AKA[$i]).msi" `
     -dDISCOVER_INSTALLDIR="$($DISCOVER_INSTALLDIR[$i])" `
-    -dDISCOVER_CONFIGDIR="$DISCOVER_CONFIGDIR" `
+    -dDISCOVER_CONFDIR="$DISCOVER_CONFDIR" `
     -ext "$($ENV:WIX)bin\WixUtilExtension.dll" `
     -ext "$($ENV:WIX)bin\WixUIExtension.dll" `
     -ext "$($ENV:WIX)bin\WixNetFxExtension.dll" `


### PR DESCRIPTION
Plus:
- Search for old and new config minion files 
- Hide checkbox "move old config" if there is no old config
- Only Set ROOTDIR to C:\salt if OLD_CONF_EXISTS and user does not want to MOVE_CONF.