### PR TITLE
Clean upgrade

### DIFF
--- a/CustomAction01/CustomAction01.cs
+++ b/CustomAction01/CustomAction01.cs
@@ -398,10 +398,12 @@ namespace MinionConfigurationExtension {
 
        [CustomAction]
         public static ActionResult DeleteConfig_DECAC(Session session) {
-            // This uninstalls the current install.
+            // This removes ROOTDIR or subfolders of ROOTDIR, depending on property REMOVE_CONFIG
+            // Called on install, upgrade and uninstall
             session.Log("...BEGIN DeleteConfig_DECAC");
 
             // Determine wether to delete everything and DIRS
+            string CLEAN_INSTALL = cutil.get_property_DECAC(session, "CLEAN_INSTALL");
             string REMOVE_CONFIG = cutil.get_property_DECAC(session, "REMOVE_CONFIG");
             string INSTALLDIR    = cutil.get_property_DECAC(session, "INSTALLDIR");
             string bindir        = Path.Combine(INSTALLDIR, "bin");
@@ -409,7 +411,7 @@ namespace MinionConfigurationExtension {
 
             // The registry subkey deletes itself
             cutil.del_dir(session, bindir, "");     // msi only deletes what it installed, not *.pyc.
-            if (REMOVE_CONFIG == "1") {
+            if (REMOVE_CONFIG.Length>0 || CLEAN_INSTALL.Length>0) {
                 cutil.del_dir(session, ROOTDIR, "");
             } else {
                 cutil.del_dir(session, ROOTDIR, "var");

--- a/HACKING.md
+++ b/HACKING.md
@@ -9,14 +9,14 @@ The build client is where the msi installer is built.
 - .Net 3.5 SDK (for WiX)<sup>*</sup>
 - [Wix 3](http://wixtoolset.org/releases/)<sup>**</sup>
 - [Build tools 2015](https://www.microsoft.com/en-US/download/confirmation.aspx?id=48159)<sup>**</sup>
-- Microsoft_VC140_CRT_x64.msm from Visual Studio 2015 in `c:\salt_msi_resources\`<sup>**</sup>
-- Microsoft_VC140_CRT_x86.msm from Visual Studio 2015 in `c:\salt_msi_resources\`<sup>**</sup>
-- Microsoft_VC120_CRT_x64.msm from Visual Studio 2013 in `c:\salt_msi_resources\`<sup>**</sup>
-- Microsoft_VC120_CRT_x86.msm from Visual Studio 2013 in `c:\salt_msi_resources\`<sup>**</sup>
+- Microsoft_VC140_CRT_x64.msm from Visual Studio 2015<sup>**</sup>
+- Microsoft_VC140_CRT_x86.msm from Visual Studio 2015<sup>**</sup>
+- Microsoft_VC120_CRT_x64.msm from Visual Studio 2013<sup>**</sup>
+- Microsoft_VC120_CRT_x86.msm from Visual Studio 2013<sup>**</sup>
 
-<sup>*</sup> `build_env.cmd` will open `optionalfeatures` if necessary.
-
-<sup>**</sup> `build_env.cmd` will download and install if necessary.
+Notes:
+- <sup>*</sup> `build_env.cmd` will open `optionalfeatures` if necessary.
+- <sup>**</sup> `build_env.cmd` will download to `.\_cache.dir` and install if necessary.
 
 How to include 64bit `rc.exe` (resource compiler) from the Windows SDK into path
 

--- a/Product.wxs
+++ b/Product.wxs
@@ -184,31 +184,37 @@ IMCAC - Immediate Custom Action - It's immediate
       -->
     <InstallExecuteSequence>
       <!--
-      On install and uninstall
+      On install and uninstall:
         stopSalt to release log file, installValidate requires access to all
         files, including the log file
       -->
-      <Custom Action='stopSalt'           Before='InstallValidate'       >1</Custom>
+      <Custom Action='stopSalt'                  Before='InstallValidate'       >1</Custom>
 
-      <Custom Action='ReadConfig_IMCAC'   Before='InstallInitialize'     >NOT Installed</Custom>
-      <Custom Action='del_NSIS_DECAC'     After='InstallInitialize'      >nsis_exe</Custom>
+      <Custom Action='ReadConfig_IMCAC'          Before='InstallInitialize'     >NOT Installed</Custom>
+      <Custom Action='del_NSIS_DECAC'            After='InstallInitialize'      >nsis_exe</Custom>
 
-      <Custom Action='MoveInsecureConfig_DECAC'   Before='CreateFolders'            >(NOT Installed) and INSECURE_CONFIG_FOUND</Custom>
-      <Custom Action='BackupConfig_DECAC' Before='CreateFolders'         >(NOT Installed) and (not INSECURE_CONFIG_FOUND) and (not MINION_CONFIG) and ((CONFIG_TYPE = "Custom") or (CONFIG_TYPE = "Default"))</Custom>
-      <Custom Action='MoveConfig_DECAC'   Before='CreateFolders'         >(NOT Installed) and MOVE_CONF</Custom>
+      <!-- If CLEAN_INSTALL, on install or upgrade: delete config and cache -->
+      <Custom Action='DeleteConfig2_CADH'
+              Before='DeleteConfig2_DECAC'                                      >CLEAN_INSTALL and ((NOT Installed) or WIX_UPGRADE_DETECTED)</Custom>
+      <Custom Action='DeleteConfig2_DECAC'        After='InstallInitialize'     >CLEAN_INSTALL and ((NOT Installed) or WIX_UPGRADE_DETECTED)</Custom>
 
-      <Custom Action='WriteConfig_CADH'   Before='WriteConfig_DECAC'     >NOT Installed</Custom>
-      <Custom Action='WriteConfig_DECAC'  After='WriteIniValues'         >NOT Installed</Custom>
+      <Custom Action='MoveInsecureConfig_DECAC'   Before='CreateFolders'        >(NOT Installed) and INSECURE_CONFIG_FOUND</Custom>
+      <Custom Action='BackupConfig_DECAC'         Before='CreateFolders'        >(NOT Installed) and (not INSECURE_CONFIG_FOUND) and (not MINION_CONFIG) and ((CONFIG_TYPE = "Custom") or (CONFIG_TYPE = "Default"))</Custom>
+      <Custom Action='MoveConfig_DECAC'           Before='CreateFolders'        >(NOT Installed) and MOVE_CONF</Custom>
+
+      <Custom Action='WriteConfig_CADH'           Before='WriteConfig_DECAC'    >NOT Installed</Custom>
+      <Custom Action='WriteConfig_DECAC'          After='WriteIniValues'        >NOT Installed</Custom>
 
       <!-- Optionally start the service  -->
       <StartServices Sequence="5900">START_MINION</StartServices>
 
-      <!-- On uninstall or upgrade, stop salt python.exe processes that would lock dll's -->
-      <Custom Action='kill_python_exe'    After='StopServices'           >(REMOVE ~= "ALL") or WIX_UPGRADE_DETECTED</Custom>
+      <!-- On uninstall or upgrade: stop salt python.exe processes that would lock dll's -->
+      <Custom Action='kill_python_exe'            After='StopServices'           >(REMOVE ~= "ALL") or WIX_UPGRADE_DETECTED</Custom>
 
+      <!-- On uninstall (not upgrade): delete config and cache -->
       <Custom Action='DeleteConfig_CADH'
-              Before='DeleteConfig_DECAC'                                >REMOVE ~= "ALL"</Custom>
-      <Custom Action='DeleteConfig_DECAC' After='RemoveFolders'          >REMOVE ~= "ALL"</Custom>
+              Before='DeleteConfig_DECAC'                                        >REMOVE ~= "ALL"</Custom>
+      <Custom Action='DeleteConfig_DECAC'         After='RemoveFolders'          >REMOVE ~= "ALL"</Custom>
 
     </InstallExecuteSequence>
 
@@ -220,13 +226,15 @@ IMCAC - Immediate Custom Action - It's immediate
     <CustomAction Id="MoveConfig_DECAC"     BinaryKey='MinionConfigExt' DllEntry='MoveConfig_DECAC'       Execute='deferred' Return='check' Impersonate='no'/>
     <CustomAction Id="WriteConfig_DECAC"    BinaryKey='MinionConfigExt' DllEntry='WriteConfig_DECAC'      Execute='deferred' Return='check' Impersonate='no'/>
     <CustomAction Id="DeleteConfig_DECAC"   BinaryKey='MinionConfigExt' DllEntry='DeleteConfig_DECAC'     Execute='deferred' Return='check' Impersonate='no'/>
+    <CustomAction Id="DeleteConfig2_DECAC"  BinaryKey='MinionConfigExt' DllEntry='DeleteConfig_DECAC'     Execute='deferred' Return='check' Impersonate='no'/>
     <CustomAction Id="BackupConfig_DECAC"   BinaryKey='MinionConfigExt' DllEntry='BackupConfig_DECAC'     Execute='deferred' Return='check' Impersonate='no'/>
     <CustomAction Id="kill_python_exe"      BinaryKey='MinionConfigExt' DllEntry='kill_python_exe'        Execute='deferred' Return='check' Impersonate='no'/>
     <!-- Custom Action Data Helper for deferred custom actions  -->
     <!-- master and id must be named like in YAML configuration -->
     <!-- Send all this stuff down to the sandbox -->
     <CustomAction Id="WriteConfig_CADH"  Property="WriteConfig_DECAC"  Value="master=[MASTER];id=[MINION_ID];MOVE_CONF=[MOVE_CONF];sourcedir=[SOURCEDIR];INSTALLDIR=[INSTALLDIR];ROOTDIR=[ROOTDIR];CONFDIR=[CONFDIR];config_type=[CONFIG_TYPE];MINION_CONFIG=[MINION_CONFIG];custom_config=[CUSTOM_CONFIG];" />
-    <CustomAction Id="DeleteConfig_CADH" Property="DeleteConfig_DECAC" Value="REMOVE_CONFIG=[REMOVE_CONFIG];INSTALLDIR=[INSTALLDIR];ROOTDIR=[ROOTDIR];" />
+    <CustomAction Id="DeleteConfig_CADH"  Property="DeleteConfig_DECAC"  Value="CLEAN_INSTALL=[CLEAN_INSTALL];REMOVE_CONFIG=[REMOVE_CONFIG];INSTALLDIR=[INSTALLDIR];ROOTDIR=[ROOTDIR];" />
+    <CustomAction Id="DeleteConfig2_CADH" Property="DeleteConfig2_DECAC" Value="CLEAN_INSTALL=[CLEAN_INSTALL];REMOVE_CONFIG=[REMOVE_CONFIG];INSTALLDIR=[INSTALLDIR];ROOTDIR=[ROOTDIR];" />
 
 
     <!-- Prevent downgrade -->
@@ -317,8 +325,10 @@ IMCAC - Immediate Custom Action - It's immediate
         </Control>
         <Control Id="StartService" Type="CheckBox"   X="25"  Y="150" Width="280" Height="15" Property="START_MINION"       CheckBoxValue="1" Text="&amp;Start salt-minion service immediately"/>
         <Control Id="HideInARP"    Type="CheckBox"   X="25"  Y="165" Width="280" Height="15" Property="ARPSYSTEMCOMPONENT" CheckBoxValue="1" Text="&amp;Hide in 'Programs and Features'"/>
-        <Control Id="remove_conf"  Type="CheckBox"   X="25"  Y="180" Width="280" Height="15" Property="REMOVE_CONFIG"      CheckBoxValue="1" Text="&amp;Remove configuration on uninstall"/>
-        <Control Id="move_conf"    Type="CheckBox"   X="25"  Y="195" Width="280" Height="15" Property="MOVE_CONF"          CheckBoxValue="1" Text="&amp;Move configuration from 'C:\salt' to 'C:\ProgramData\Salt Project'.">
+        <Control Id="conf_txt"     Type="Text"       X="36"  Y="182" Width="130" Height="15"                                                 Text="Remove configuration and cache on"/>
+        <Control Id="clean_inst"   Type="CheckBox"   X="170" Y="180" Width="50"  Height="15" Property="CLEAN_INSTALL"      CheckBoxValue="1" Text="u&amp;pgrade"/>
+        <Control Id="remove_conf"  Type="CheckBox"   X="220" Y="180" Width="50"  Height="15" Property="REMOVE_CONFIG"      CheckBoxValue="1" Text="&amp;uninstall"/>
+        <Control Id="move_conf"    Type="CheckBox"   X="25"  Y="195" Width="280" Height="15" Property="MOVE_CONF"          CheckBoxValue="1" Text="&amp;Move configuration from &quot;C:\salt&quot; to &quot;C:\ProgramData\Salt Project&quot;">
           <Condition Action="show">     OLD_CONF_EXISTS</Condition>
           <Condition Action="hide">not (OLD_CONF_EXISTS)</Condition>
         </Control>

--- a/Product.wxs
+++ b/Product.wxs
@@ -326,8 +326,8 @@ IMCAC - Immediate Custom Action - It's immediate
         <Control Id="StartService" Type="CheckBox"   X="25"  Y="150" Width="280" Height="15" Property="START_MINION"       CheckBoxValue="1" Text="&amp;Start salt-minion service immediately"/>
         <Control Id="HideInARP"    Type="CheckBox"   X="25"  Y="165" Width="280" Height="15" Property="ARPSYSTEMCOMPONENT" CheckBoxValue="1" Text="&amp;Hide in 'Programs and Features'"/>
         <Control Id="conf_txt"     Type="Text"       X="36"  Y="182" Width="130" Height="15"                                                 Text="Remove configuration and cache:"/>
-        <Control Id="clean_inst"   Type="CheckBox"   X="166" Y="180" Width="70"  Height="15" Property="CLEAN_INSTALL"      CheckBoxValue="1" Text="Before u&amp;pgrade"/>
-        <Control Id="remove_conf"  Type="CheckBox"   X="244" Y="180" Width="60"  Height="15" Property="REMOVE_CONFIG"      CheckBoxValue="1" Text="On &amp;uninstall"/>
+        <Control Id="clean_inst"   Type="CheckBox"   X="166" Y="180" Width="70"  Height="15" Property="CLEAN_INSTALL"      CheckBoxValue="1" Text="B&amp;efore upgrade"/>
+        <Control Id="remove_conf"  Type="CheckBox"   X="244" Y="180" Width="60"  Height="15" Property="REMOVE_CONFIG"      CheckBoxValue="1" Text="&amp;On uninstall"/>
         <Control Id="move_conf"    Type="CheckBox"   X="25"  Y="195" Width="280" Height="15" Property="MOVE_CONF"          CheckBoxValue="1" Text="&amp;Move configuration from &quot;C:\salt&quot; to &quot;C:\ProgramData\Salt Project&quot;">
           <Condition Action="show">     OLD_CONF_EXISTS</Condition>
           <Condition Action="hide">not (OLD_CONF_EXISTS)</Condition>

--- a/Product.wxs
+++ b/Product.wxs
@@ -310,11 +310,11 @@ IMCAC - Immediate Custom Action - It's immediate
         <Control Id="MasterId"     Type="Edit"       X="30"  Y="70"  Width="190" Height="15" Property="MASTER" />
         <Control Id="MinionLabel"  Type="Text"       X="20"  Y="85"  Width="280" Height="15" Transparent="yes" NoPrefix="yes" Text="Minion:" />
         <Control Id="MinionId"     Type="Edit"       X="30"  Y="100" Width="190" Height="15" Property="MINION_ID" />
-        <Control Id="cbt_type"     Type="Text"       X="20"  Y="125"  Width="40" Height="15" Transparent="yes" NoPrefix="yes" Text="Config type">
+        <Control Id="cbt_type"     Type="Text"       X="20"  Y="125"  Width="45" Height="15" Transparent="yes" NoPrefix="yes" Text="Config type:">
           <Condition Action="show">not (MINION_CONFIG or INSECURE_CONFIG_FOUND)</Condition>
           <Condition Action="hide">     MINION_CONFIG or INSECURE_CONFIG_FOUND</Condition>
         </Control>
-        <Control Id="cbo_type"     Type="ComboBox"   X="70"  Y="125"  Width="50" Height="15" Property="CONFIG_TYPE" >
+        <Control Id="cbo_type"     Type="ComboBox"   X="75"  Y="125"  Width="60" Height="15" Property="CONFIG_TYPE" >
             <ComboBox Property="CONFIG_TYPE">
                 <ListItem Value="Existing" />
                 <ListItem Value="Custom" />
@@ -325,9 +325,9 @@ IMCAC - Immediate Custom Action - It's immediate
         </Control>
         <Control Id="StartService" Type="CheckBox"   X="25"  Y="150" Width="280" Height="15" Property="START_MINION"       CheckBoxValue="1" Text="&amp;Start salt-minion service immediately"/>
         <Control Id="HideInARP"    Type="CheckBox"   X="25"  Y="165" Width="280" Height="15" Property="ARPSYSTEMCOMPONENT" CheckBoxValue="1" Text="&amp;Hide in 'Programs and Features'"/>
-        <Control Id="conf_txt"     Type="Text"       X="36"  Y="182" Width="130" Height="15"                                                 Text="Remove configuration and cache on"/>
-        <Control Id="clean_inst"   Type="CheckBox"   X="170" Y="180" Width="50"  Height="15" Property="CLEAN_INSTALL"      CheckBoxValue="1" Text="u&amp;pgrade"/>
-        <Control Id="remove_conf"  Type="CheckBox"   X="220" Y="180" Width="50"  Height="15" Property="REMOVE_CONFIG"      CheckBoxValue="1" Text="&amp;uninstall"/>
+        <Control Id="conf_txt"     Type="Text"       X="36"  Y="182" Width="130" Height="15"                                                 Text="Remove configuration and cache:"/>
+        <Control Id="clean_inst"   Type="CheckBox"   X="166" Y="180" Width="70"  Height="15" Property="CLEAN_INSTALL"      CheckBoxValue="1" Text="Before u&amp;pgrade"/>
+        <Control Id="remove_conf"  Type="CheckBox"   X="244" Y="180" Width="60"  Height="15" Property="REMOVE_CONFIG"      CheckBoxValue="1" Text="On &amp;uninstall"/>
         <Control Id="move_conf"    Type="CheckBox"   X="25"  Y="195" Width="280" Height="15" Property="MOVE_CONF"          CheckBoxValue="1" Text="&amp;Move configuration from &quot;C:\salt&quot; to &quot;C:\ProgramData\Salt Project&quot;">
           <Condition Action="show">     OLD_CONF_EXISTS</Condition>
           <Condition Action="hide">not (OLD_CONF_EXISTS)</Condition>

--- a/Product.wxs
+++ b/Product.wxs
@@ -237,11 +237,11 @@ IMCAC - Immediate Custom Action - It's immediate
     <DirectoryRef Id="TARGETDIR">
     <!-- Visual C++ runtimes depend on the target platform -->
     <?if $(var.WIN64)=yes ?>
-      <Merge Id="MSM_VC120_CRT" SourceFile="c:\salt_msi_resources\Microsoft_VC120_CRT_x64.msm" DiskId="1" Language="0"/>
-      <Merge Id="MSM_VC140_CRT" SourceFile="c:\salt_msi_resources\Microsoft_VC140_CRT_x64.msm" DiskId="1" Language="0"/>
+      <Merge Id="MSM_VC120_CRT" SourceFile="$(var.WEBCACHE_DIR)\Microsoft_VC120_CRT_x64.msm" DiskId="1" Language="0"/>
+      <Merge Id="MSM_VC140_CRT" SourceFile="$(var.WEBCACHE_DIR)\Microsoft_VC140_CRT_x64.msm" DiskId="1" Language="0"/>
     <?else ?>
-      <Merge Id="MSM_VC120_CRT" SourceFile="c:\salt_msi_resources\Microsoft_VC120_CRT_x86.msm" DiskId="1" Language="0"/>
-      <Merge Id="MSM_VC140_CRT" SourceFile="c:\salt_msi_resources\Microsoft_VC140_CRT_x86.msm" DiskId="1" Language="0"/>
+      <Merge Id="MSM_VC120_CRT" SourceFile="$(var.WEBCACHE_DIR)\Microsoft_VC120_CRT_x86.msm" DiskId="1" Language="0"/>
+      <Merge Id="MSM_VC140_CRT" SourceFile="$(var.WEBCACHE_DIR)\Microsoft_VC140_CRT_x86.msm" DiskId="1" Language="0"/>
     <?endif ?>
     </DirectoryRef>
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Salt Minion-specific and generic msi-properties:
  `START_MINION`         | `1`                     | Set to `""` to prevent the start of the `salt-minion` service.
  `MOVE_CONF`            |                         | Set to 1 to move configuration from `C:\salt` to `%ProgramData%`.
  `REMOVE_CONFIG`        |                         | Set to 1 to remove configuration on uninstall. Implied by `MINION_CONFIG`.
+ `CLEAN_INSTALL`        |                         | Set to 1 to remove configuration and cache on install or upgrade.
  `CONFIG_TYPE`          | `Existing`              | Or `Custom` or `Default`. See below.
  `CUSTOM_CONFIG`        |                         | Name of a custom config file in the same path as the installer or full path. Requires `CONFIG_TYPE=Custom`. __ONLY FROM COMMANDLINE__
  `INSTALLDIR`           | Windows default         | Where to install (`INSTALLFOLDER` is deprecated)

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Salt Minion-specific and generic msi-properties:
  `START_MINION`         | `1`                     | Set to `""` to prevent the start of the `salt-minion` service.
  `MOVE_CONF`            |                         | Set to 1 to move configuration from `C:\salt` to `%ProgramData%`.
  `REMOVE_CONFIG`        |                         | Set to 1 to remove configuration on uninstall. Implied by `MINION_CONFIG`.
- `CLEAN_INSTALL`        |                         | Set to 1 to remove configuration and cache on install or upgrade.
+ `CLEAN_INSTALL`        |                         | Set to 1 to remove configuration and cache before install or upgrade.
  `CONFIG_TYPE`          | `Existing`              | Or `Custom` or `Default`. See below.
  `CUSTOM_CONFIG`        |                         | Name of a custom config file in the same path as the installer or full path. Requires `CONFIG_TYPE=Custom`. __ONLY FROM COMMANDLINE__
  `INSTALLDIR`           | Windows default         | Where to install (`INSTALLFOLDER` is deprecated)

--- a/build.ps1
+++ b/build.ps1
@@ -5,6 +5,14 @@
 Set-PSDebug -Strict
 Set-strictmode -version latest
 
+
+# Until 2022 or executed on each dev box: move old cache to new cache dir
+if (Test-Path C:\salt_msi_resources) {
+  Move-Item C:\salt_msi_resources\* .\_cache.dir -force
+  Remove-Item C:\salt_msi_resources
+}
+
+
 # # # Detecting Salt version from Git # # #
 if (-Not (Test-Path ..\salt)) {
   Write-Host -ForegroundColor Red No directory ..\salt
@@ -67,6 +75,7 @@ $PRODUCTDIR     = "Salt"
 $VERSION        = $internalversion
 $DISCOVER_INSTALLDIR = "..\salt\pkg\windows\buildenv", "..\salt\pkg\windows\buildenv"
 $DISCOVER_CONFDIR    = "..\salt\pkg\windows\buildenv\conf"
+$WEBCACHE_DIR        = "$pwd\_cache.dir"
 
 # MSBUild needed to compile C#
 If ( (Get-CimInstance Win32_OperatingSystem).OSArchitecture -eq "64-bit" ) {
@@ -177,6 +186,7 @@ Write-Host -ForegroundColor Yellow "Compiling    *.wxs to $($ARCHITECTURE[$i]) *
     -dDisplayVersion="$displayversion" `
     -dInternalVersion="$internalversion" `
     -dDISCOVER_INSTALLDIR="$($DISCOVER_INSTALLDIR[$i])" `
+    -dWEBCACHE_DIR="$WEBCACHE_DIR" `
     -dDISCOVER_CONFDIR="$DISCOVER_CONFDIR" `
     -ext "$($ENV:WIX)bin\WixUtilExtension.dll" `
     -ext "$($ENV:WIX)bin\WixUIExtension.dll" `

--- a/build_env.ps1
+++ b/build_env.ps1
@@ -1,5 +1,5 @@
 ###
-###  Downloads software to c:\salt_msi_resources
+###  Downloads software
 ###
 Set-PSDebug -Strict
 Set-strictmode -version latest
@@ -9,9 +9,8 @@ Import-Module $PSScriptRoot\setupUtil.psm1
 
 #### Ensure path exists
 ####
-$salt_msi_resources = "c:/salt_msi_resources"
-# mkdir must be guarded, and I don't want to send the result of is-dir to console
-$ignore_bool = (Test-Path -Path $salt_msi_resources) -Or (New-Item -ItemType directory -Path $salt_msi_resources)
+$WEBCACHE_DIR = "$pwd\_cache.dir"
+$ignore_bool = (Test-Path -Path $WEBCACHE_DIR) -Or (New-Item -ItemType directory -Path $WEBCACHE_DIR)
 
 
 #### Ensure resources are installed or get them
@@ -21,18 +20,18 @@ $ignore_bool = (Test-Path -Path $salt_msi_resources) -Or (New-Item -ItemType dir
 ## See Product.md
 
 ## VC++ Runtime 2015
-VerifyOrDownload "c:/salt_msi_resources/Microsoft_VC140_CRT_x64.msm" `
+VerifyOrDownload "$pwd\_cache.dir\Microsoft_VC140_CRT_x64.msm" `
     "http://repo.saltstack.com/windows/dependencies/64/Microsoft_VC140_CRT_x64.msm" `
     "E1344D5943FB2BBB7A56470ED0B7E2B9B212CD9210D3CC6FA82BC3DA8F11EDA8"
 
-VerifyOrDownload "c:/salt_msi_resources/Microsoft_VC140_CRT_x86.msm" `
+VerifyOrDownload "$pwd\_cache.dir\Microsoft_VC140_CRT_x86.msm" `
     "http://repo.saltstack.com/windows/dependencies/32/Microsoft_VC140_CRT_x86.msm" `
     "0D36CFE6E9ABD7F530DBAA4A83841CDBEF9B2ADCB625614AF18208FDCD6B92A4"
 
 ## VC++ Runtime 2013
-VerifyOrDownload "c:/salt_msi_resources/Microsoft_VC120_CRT_x64.msm" `
+VerifyOrDownload "$pwd\_cache.dir\Microsoft_VC120_CRT_x64.msm" `
     "http://repo.saltstack.com/windows/dependencies/64/Microsoft_VC120_CRT_x64.msm" `
     "15FD10A495287505184B8913DF8D6A9CA461F44F78BC74115A0C14A5EDD1C9A7"
-VerifyOrDownload "c:/salt_msi_resources/Microsoft_VC120_CRT_x86.msm" `
+VerifyOrDownload "$pwd\_cache.dir\Microsoft_VC120_CRT_x86.msm" `
     "http://repo.saltstack.com/windows/dependencies/32/Microsoft_VC120_CRT_x86.msm" `
     "26340B393F52888B908AC3E67B935A80D390E1728A31FF38EBCEC01117EB2579"


### PR DESCRIPTION
Safe guard against any backup folder when you can afford to loose config and cache

Reuse DeleteConfig_DECAC at install or upgrade.

Must be referenced as `DeleteConfig2_DECAC` because of unique constraints of some table.

 
![image](https://user-images.githubusercontent.com/8489107/133325126-f30f8cd4-01fc-4756-a367-0d7729138013.png)
