### PR TITLE
Only get config template when config is missing

### DIFF
--- a/CustomAction01/CustomAction01.cs
+++ b/CustomAction01/CustomAction01.cs
@@ -106,9 +106,12 @@ namespace MinionConfigurationExtension {
                     // - set INSECURE_CONFIG_FOUND to True
                     // - set CONFIG_TYPE to Default
                     session.Log("...Insecure config found, using default config");
-                    session["INSECURE_CONFIG_FOUND"] = "True";
+                    session["INSECURE_CONFIG_FOUND"] = "True";      // Will trigger rename of the folder
                     session["CONFIG_TYPE"] = "Default";
+                    session["GET_CONFIG_TEMPLATE_FROM_MSI_STORE"] = "True";    // Use template instead
                 }
+            } else {
+                session["GET_CONFIG_TEMPLATE_FROM_MSI_STORE"] = "True";    // Use template
             }
 
             // Set the default values for master and id

--- a/Product.wxs
+++ b/Product.wxs
@@ -190,7 +190,8 @@ IMCAC - Immediate Custom Action - It's immediate
       -->
       <Custom Action='stopSalt'                  Before='InstallValidate'       >1</Custom>
 
-      <Custom Action='ReadConfig_IMCAC'          Before='InstallInitialize'     >NOT Installed</Custom>
+      <!-- ReadConfig_IMCAC must be called before CostInitialize so features can depend on properties set-->
+      <Custom Action='ReadConfig_IMCAC'          Before='CostInitialize'        >NOT Installed</Custom>
       <Custom Action='del_NSIS_DECAC'            After='InstallInitialize'      >nsis_install_found</Custom>
 
       <!-- If CLEAN_INSTALL, on install or upgrade: delete config and cache -->
@@ -268,9 +269,15 @@ IMCAC - Immediate Custom Action - It's immediate
       <Feature Id="VC120" Title="VC++ 2013" AllowAdvertise="no" Display="hidden"><MergeRef Id="MSM_VC120_CRT"/></Feature>
       <Feature Id="VC140" Title="VC++ 2015" AllowAdvertise="no" Display="hidden"><MergeRef Id="MSM_VC140_CRT"/></Feature>
     </Feature>
+
+    <!-- Get the config file template from the msi store only if no config is present -->
+    <Feature Id='GetConfigTemplate' Level='0'>
+        <ComponentGroupRef Id="DiscoveredConfigFiles" />
+        <Condition Level="1">GET_CONFIG_TEMPLATE_FROM_MSI_STORE or (REMOVE ~= "ALL")</Condition>
+    </Feature>
+
     <ComponentGroup Id="ProductComponents" Directory="INSTALLDIR">
       <ComponentGroupRef Id="DiscoveredBinaryFiles" />
-      <ComponentGroupRef Id="DiscoveredConfigFiles" />
       <ComponentGroupRef Id="service" />
       <ComponentRef Id="INSTALLDIR_Permissions" />
       <ComponentRef Id="ROOTDIR_Permissions" />


### PR DESCRIPTION
- Before: template overwrites existing config.
- Testing
